### PR TITLE
feat: warn-on-blind-noop reconciler safety net + KindAgentLink resource

### DIFF
--- a/internal/manifest/field_config.go
+++ b/internal/manifest/field_config.go
@@ -27,6 +27,10 @@ var writeOnlyFields = map[ResourceKind][]string{
 	KindMCPCredentials:    {"credentials"},      // credentials are write-only (encrypted)
 	KindSecureCLI:         {"env"},              // encrypted env vars are write-only
 	KindSecureCLIGrant:    {"agentKey", "binaryName"}, // manifest references, not in API response
+	KindAgentLink: {
+		"sourceAgent", "targetAgent", // manifest references resolved to UUIDs at create time
+		"settings", // per-user grants and rate limits — JSONB write-only
+	},
 }
 
 // WriteOnlyFields returns the write-only fields for a resource kind.

--- a/internal/manifest/types.go
+++ b/internal/manifest/types.go
@@ -42,6 +42,7 @@ const (
 	KindSystemConfig      ResourceKind = "SystemConfig"
 	KindSecureCLI         ResourceKind = "SecureCLI"
 	KindSecureCLIGrant    ResourceKind = "SecureCLIGrant"
+	KindAgentLink         ResourceKind = "AgentLink"
 )
 
 // Resource is a generic managed resource with kind + name + arbitrary spec.
@@ -73,5 +74,6 @@ func ApplyOrder() []ResourceKind {
 		KindSecureCLI,         // depends on Tenant
 		KindSecureCLIGrant,    // depends on SecureCLI + Agent
 		KindAgentTeam,         // no strict deps
+		KindAgentLink,         // depends on Agent (source + target); placed after AgentTeam to coexist with team-managed links
 	}
 }

--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -26,6 +26,7 @@ var validKinds = map[ResourceKind]bool{
 	KindMCPCredentials:    true,
 	KindSecureCLI:         true,
 	KindSecureCLIGrant:    true,
+	KindAgentLink:         true,
 }
 
 // Validate checks the manifest for structural errors.

--- a/internal/manifest/validate_refs.go
+++ b/internal/manifest/validate_refs.go
@@ -1,6 +1,20 @@
 package manifest
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
+
+// splitAgentLinkName mirrors the provider-side parser for composite AgentLink
+// names. Kept here so the manifest validator can reject malformed names without
+// importing the provider package.
+func splitAgentLinkName(name string) (string, string, error) {
+	parts := strings.Split(name, "--")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid AgentLink name %q: expected format sourceAgent--targetAgent", name)
+	}
+	return parts[0], parts[1], nil
+}
 
 // validateReferences checks cross-resource references in the manifest.
 // Returns all broken references as errors (not fail-on-first).
@@ -73,6 +87,31 @@ func validateReferences(m *Manifest) []error {
 				if !index[KindAgent][member] {
 					errs = append(errs, fmt.Errorf("%s: member references Agent %q which is not declared", prefix, member))
 				}
+			}
+		case KindAgentLink:
+			// Composite name "sourceAgent--targetAgent" is the canonical identity.
+			// spec.sourceAgent / spec.targetAgent must agree with the name halves
+			// (when provided) to prevent silent divergence between manifest intent
+			// and the resolved API call.
+			nameSrc, nameTgt, parseErr := splitAgentLinkName(r.Name)
+			if parseErr != nil {
+				errs = append(errs, fmt.Errorf("%s: %v", prefix, parseErr))
+				continue
+			}
+			specSrc := specStr(r.Spec, "sourceAgent")
+			specTgt := specStr(r.Spec, "targetAgent")
+			if specSrc != "" && specSrc != nameSrc {
+				errs = append(errs, fmt.Errorf("%s: spec.sourceAgent %q must match name prefix %q", prefix, specSrc, nameSrc))
+			}
+			if specTgt != "" && specTgt != nameTgt {
+				errs = append(errs, fmt.Errorf("%s: spec.targetAgent %q must match name suffix %q", prefix, specTgt, nameTgt))
+			}
+			// Both halves must reference declared Agents.
+			if !index[KindAgent][nameSrc] {
+				errs = append(errs, fmt.Errorf("%s: sourceAgent references Agent %q which is not declared", prefix, nameSrc))
+			}
+			if !index[KindAgent][nameTgt] {
+				errs = append(errs, fmt.Errorf("%s: targetAgent references Agent %q which is not declared", prefix, nameTgt))
 			}
 		}
 	}

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -214,6 +214,82 @@ func TestValidateReferences_BrokenTeamLead(t *testing.T) {
 	}
 }
 
+func TestValidateReferences_BrokenAgentLink(t *testing.T) {
+	// Spec values match name halves but agents are not declared.
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindAgentLink, Name: "ghost--also-ghost", Spec: map[string]any{
+				"sourceAgent": "ghost",
+				"targetAgent": "also-ghost",
+			}},
+		},
+	}
+	errs := Validate(m)
+	hasSrc, hasTgt := false, false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "sourceAgent") && strings.Contains(e.Error(), "ghost") {
+			hasSrc = true
+		}
+		if strings.Contains(e.Error(), "targetAgent") && strings.Contains(e.Error(), "also-ghost") {
+			hasTgt = true
+		}
+	}
+	if !hasSrc || !hasTgt {
+		t.Errorf("expected ref errors for both sourceAgent and targetAgent, got: %v", errs)
+	}
+}
+
+func TestValidateReferences_AgentLinkSpecNameMismatch(t *testing.T) {
+	// Composite name says "planner--coder" but spec.sourceAgent says "ghost".
+	// Without the name-match rule, the create call would silently use the name.
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindProvider, Name: "p", Spec: map[string]any{}},
+			{Kind: KindAgent, Name: "planner", Spec: map[string]any{"provider": "p"}},
+			{Kind: KindAgent, Name: "coder", Spec: map[string]any{"provider": "p"}},
+			{Kind: KindAgentLink, Name: "planner--coder", Spec: map[string]any{
+				"sourceAgent": "ghost", // mismatch
+				"targetAgent": "coder",
+			}},
+		},
+	}
+	errs := Validate(m)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "must match name prefix") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected name-prefix mismatch error, got: %v", errs)
+	}
+}
+
+func TestValidateReferences_AgentLinkBadName(t *testing.T) {
+	// 3-segment name should be rejected by the validator.
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindAgentLink, Name: "a--b--c", Spec: map[string]any{}},
+		},
+	}
+	errs := Validate(m)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Error(), "invalid AgentLink name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected invalid-name error for 3-segment composite, got: %v", errs)
+	}
+}
+
 func TestValidateReferences_MultipleErrors(t *testing.T) {
 	m := &Manifest{
 		APIVersion: "gcplane.io/v1",

--- a/internal/provider/goclaw/agent_link_test.go
+++ b/internal/provider/goclaw/agent_link_test.go
@@ -1,0 +1,305 @@
+package goclaw
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/dataplanelabs/gcplane/internal/manifest"
+)
+
+// agentsHandlerForLinks returns an HTTP handler that serves /v1/agents with the
+// given agent fixtures keyed by agent_key → id.
+func agentsHandlerForLinks(t *testing.T, agents []map[string]any) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/agents" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"agents": agents})
+			return
+		}
+		http.NotFound(w, r)
+	}
+}
+
+func TestAgentLink_ParseName(t *testing.T) {
+	cases := []struct {
+		in       string
+		src, tgt string
+		ok       bool
+	}{
+		{"planner--coder", "planner", "coder", true},
+		{"a--b", "a", "b", true},
+		{"missing-target", "", "", false},
+		{"--orphan", "", "", false},
+		{"orphan--", "", "", false},
+		{"", "", "", false},
+		// 3+ segments rejected — agent_keys may not contain "--"
+		{"a--b--c", "", "", false},
+		{"a--b--c--d", "", "", false},
+	}
+	for _, c := range cases {
+		s, tg, err := parseAgentLinkName(c.in)
+		if c.ok && err != nil {
+			t.Errorf("parseAgentLinkName(%q): unexpected error %v", c.in, err)
+		}
+		if !c.ok && err == nil {
+			t.Errorf("parseAgentLinkName(%q): expected error", c.in)
+		}
+		if c.ok && (s != c.src || tg != c.tgt) {
+			t.Errorf("parseAgentLinkName(%q): got (%q,%q), want (%q,%q)", c.in, s, tg, c.src, c.tgt)
+		}
+	}
+}
+
+func TestAgentLink_Observe_Found(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+	}
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "agents.links.list", ok: true, payload: map[string]any{
+			"links": []map[string]any{
+				{
+					"id":              "link-uuid",
+					"source_agent_id": "src-id",
+					"target_agent_id": "tgt-id",
+					"direction":       "outbound",
+					"description":     "Planner delegates to Coder",
+					"max_concurrent":  3,
+					"status":          "active",
+					"created_by":      "gcplane",
+				},
+			},
+		}},
+	}, agentsHandlerForLinks(t, agents))
+	defer cleanup()
+
+	result, err := p.Observe(context.Background(), manifest.KindAgentLink, "planner--coder")
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result["direction"] != "outbound" {
+		t.Errorf("direction: got %v, want outbound", result["direction"])
+	}
+	if result["description"] != "Planner delegates to Coder" {
+		t.Errorf("description mismatch: %v", result["description"])
+	}
+	if result["status"] != "active" {
+		t.Errorf("status: got %v, want active", result["status"])
+	}
+	// id must remain (needed for update/delete)
+	if result["id"] != "link-uuid" {
+		t.Errorf("id stripped or mismatched: %v", result["id"])
+	}
+	// Joined / identity fields must be stripped
+	for _, f := range []string{"sourceAgentId", "targetAgentId", "sourceAgentKey", "targetAgentKey", "teamId"} {
+		if _, has := result[f]; has {
+			t.Errorf("internal field %q should be stripped", f)
+		}
+	}
+}
+
+func TestAgentLink_Observe_NotFound_NoMatch(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+		{"id": "other-id", "agent_key": "other"},
+	}
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "agents.links.list", ok: true, payload: map[string]any{
+			"links": []map[string]any{
+				// link from planner exists but to a different target
+				{
+					"id":              "link-uuid",
+					"source_agent_id": "src-id",
+					"target_agent_id": "other-id",
+					"direction":       "outbound",
+					"status":          "active",
+				},
+			},
+		}},
+	}, agentsHandlerForLinks(t, agents))
+	defer cleanup()
+
+	result, err := p.Observe(context.Background(), manifest.KindAgentLink, "planner--coder")
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestAgentLink_Observe_BadName(t *testing.T) {
+	p, cleanup := newWSTestServer(t, nil, nil)
+	defer cleanup()
+
+	_, err := p.Observe(context.Background(), manifest.KindAgentLink, "missing-target")
+	if err == nil {
+		t.Fatal("expected error for malformed name")
+	}
+}
+
+func TestAgentLink_Create(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+	}
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "agents.links.create", ok: true, payload: map[string]any{"link": map[string]any{"id": "new-link"}}},
+	}, agentsHandlerForLinks(t, agents))
+	defer cleanup()
+
+	err := p.Create(context.Background(), manifest.KindAgentLink, "planner--coder", map[string]any{
+		"direction":     "outbound",
+		"description":   "delegates impl",
+		"maxConcurrent": 5,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+}
+
+func TestAgentLink_Update(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+	}
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "agents.links.list", ok: true, payload: map[string]any{
+			"links": []map[string]any{
+				{
+					"id":              "link-uuid",
+					"source_agent_id": "src-id",
+					"target_agent_id": "tgt-id",
+					"direction":       "outbound",
+					"status":          "active",
+				},
+			},
+		}},
+		{method: "agents.links.update", ok: true, payload: map[string]any{"ok": true}},
+	}, agentsHandlerForLinks(t, agents))
+	defer cleanup()
+
+	err := p.Update(context.Background(), manifest.KindAgentLink, "planner--coder", map[string]any{
+		"description":   "updated",
+		"maxConcurrent": 10,
+		"status":        "disabled",
+	})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+}
+
+func TestAgentLink_Update_NotFound(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+	}
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "agents.links.list", ok: true, payload: map[string]any{"links": []map[string]any{}}},
+	}, agentsHandlerForLinks(t, agents))
+	defer cleanup()
+
+	err := p.Update(context.Background(), manifest.KindAgentLink, "planner--coder", map[string]any{"description": "x"})
+	if err == nil {
+		t.Fatal("expected error updating non-existent link")
+	}
+}
+
+func TestAgentLink_Delete(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+	}
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "agents.links.list", ok: true, payload: map[string]any{
+			"links": []map[string]any{
+				{
+					"id":              "link-uuid",
+					"source_agent_id": "src-id",
+					"target_agent_id": "tgt-id",
+					"direction":       "outbound",
+					"status":          "active",
+				},
+			},
+		}},
+		{method: "agents.links.delete", ok: true, payload: map[string]any{"ok": true}},
+	}, agentsHandlerForLinks(t, agents))
+	defer cleanup()
+
+	if err := p.Delete(context.Background(), manifest.KindAgentLink, "planner--coder"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+}
+
+func TestAgentLink_Delete_Idempotent(t *testing.T) {
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+	}
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "agents.links.list", ok: true, payload: map[string]any{"links": []map[string]any{}}},
+	}, agentsHandlerForLinks(t, agents))
+	defer cleanup()
+
+	if err := p.Delete(context.Background(), manifest.KindAgentLink, "planner--coder"); err != nil {
+		t.Fatalf("idempotent delete should not error: %v", err)
+	}
+}
+
+func TestAgentLink_ListAll_SkipsTeamManaged(t *testing.T) {
+	// One source agent (planner), one target (coder, no outbound links).
+	// Mock returns the canned response for every agents.links.list call,
+	// but we only expect emissions for planner → coder. Since coder is also
+	// queried as a source, we use a smart handler that returns empty for coder.
+	agents := []map[string]any{
+		{"id": "src-id", "agent_key": "planner"},
+		{"id": "tgt-id", "agent_key": "coder"},
+	}
+	p, cleanup := newWSTestServerSmart(t, agents, map[string][]map[string]any{
+		"src-id": {
+			{
+				"id":              "user-link",
+				"source_agent_id": "src-id",
+				"target_agent_id": "tgt-id",
+				"direction":       "outbound",
+				"status":          "active",
+				"created_by":      "gcplane",
+			},
+			{
+				"id":              "team-link",
+				"source_agent_id": "src-id",
+				"target_agent_id": "tgt-id",
+				"team_id":         "team-uuid", // managed by AgentTeam — must be skipped
+				"direction":       "outbound",
+				"status":          "active",
+				"created_by":      "gcplane",
+			},
+		},
+		"tgt-id": {}, // coder has no outbound links
+	})
+	defer cleanup()
+
+	infos, err := p.ListAll(context.Background(), manifest.KindAgentLink)
+	if err != nil {
+		t.Fatalf("listAll: %v", err)
+	}
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 user-link (team-link skipped), got %d: %+v", len(infos), infos)
+	}
+	got := infos[0]
+	if got.Kind != manifest.KindAgentLink {
+		t.Errorf("kind: got %s, want AgentLink", got.Kind)
+	}
+	if got.Name != "planner--coder" {
+		t.Errorf("name: got %s, want planner--coder", got.Name)
+	}
+	if got.CreatedBy != "gcplane" {
+		t.Errorf("created_by: got %s, want gcplane", got.CreatedBy)
+	}
+}

--- a/internal/provider/goclaw/agent_links.go
+++ b/internal/provider/goclaw/agent_links.go
@@ -1,0 +1,171 @@
+package goclaw
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// agentLinkInternalFields are link-specific fields returned by GoClaw WS RPC
+// (snake_case in JSON tags) that should be stripped from observe results.
+// Identity is encoded in the manifest name (sourceKey--targetKey); the
+// resolved UUIDs and joined denormalized fields would otherwise cause phantom diffs.
+var agentLinkInternalFields = []string{
+	"sourceAgentId", "targetAgentId",
+	"sourceAgentKey", "sourceDisplayName", "sourceEmoji",
+	"targetAgentKey", "targetDisplayName", "targetEmoji", "targetDescription",
+	"teamId", "teamName", "targetIsTeamLead", "targetTeamName",
+}
+
+// parseAgentLinkName splits a composite link name "sourceAgent--targetAgent"
+// into its parts. Returns an error if the format is invalid (missing separator,
+// empty halves, or 3+ segments — agent_keys may not contain "--").
+func parseAgentLinkName(name string) (sourceKey, targetKey string, err error) {
+	parts := strings.Split(name, "--")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid agent link name %q: expected format sourceAgent--targetAgent (agent_keys may not contain %q)", name, "--")
+	}
+	return parts[0], parts[1], nil
+}
+
+// observeAgentLink fetches an agent link by composite name via WS RPC.
+// Strategy: resolve sourceKey → sourceID, list links from that source, find target.
+func (p *Provider) observeAgentLink(ctx context.Context, key string) (map[string]any, error) {
+	if err := p.ensureWS(ctx); err != nil {
+		return nil, fmt.Errorf("ws connect for agent links: %w", err)
+	}
+
+	sourceKey, targetKey, err := parseAgentLinkName(key)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceID, err := p.resolveAgentID(ctx, sourceKey)
+	if err != nil {
+		return nil, fmt.Errorf("link %s: source: %w", key, err)
+	}
+	targetID, err := p.resolveAgentID(ctx, targetKey)
+	if err != nil {
+		return nil, fmt.Errorf("link %s: target: %w", key, err)
+	}
+
+	payload, err := p.ws.Call(ctx, "agents.links.list", map[string]any{
+		"agentId":   sourceID,
+		"direction": "from",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("agents.links.list: %w", err)
+	}
+
+	var resp struct {
+		Links []map[string]any `json:"links"`
+	}
+	if err := json.Unmarshal(payload, &resp); err != nil {
+		return nil, fmt.Errorf("parse agents.links.list response: %w", err)
+	}
+
+	for _, link := range resp.Links {
+		// AgentLinkData json tags are snake_case; translateResult converts to camelCase.
+		camel := translateResult(link)
+		if strVal(camel, "targetAgentId") != targetID {
+			continue
+		}
+		// Keep id for update/delete; strip joined denorm fields.
+		result := stripInternal(copyMap(link))
+		result = translateResult(result)
+		for _, f := range agentLinkInternalFields {
+			delete(result, f)
+		}
+		return result, nil
+	}
+	return nil, nil
+}
+
+// createAgentLink creates a new agent link via WS RPC.
+// agents.links.* uses camelCase JSON (no translateSpec needed).
+func (p *Provider) createAgentLink(ctx context.Context, key string, spec map[string]any) error {
+	if err := p.ensureWS(ctx); err != nil {
+		return fmt.Errorf("ws connect for agent links: %w", err)
+	}
+
+	sourceKey, targetKey, err := parseAgentLinkName(key)
+	if err != nil {
+		return err
+	}
+
+	// sourceAgent / targetAgent in spec must agree with the composite name.
+	// If spec provides them, prefer the composite-name keys to avoid divergence.
+	params := copyMap(spec)
+	params["sourceAgent"] = sourceKey
+	params["targetAgent"] = targetKey
+
+	// Strip manifest-only marker keys that aren't part of the create RPC.
+	// (settings, direction, description, maxConcurrent pass through directly.)
+
+	if _, err := p.ws.Call(ctx, "agents.links.create", params); err != nil {
+		return fmt.Errorf("agents.links.create %s: %w", key, err)
+	}
+	return nil
+}
+
+// updateAgentLink patches an existing agent link via WS RPC.
+// agents.links.update takes linkId — Observe first to resolve it.
+func (p *Provider) updateAgentLink(ctx context.Context, key string, spec map[string]any) error {
+	if err := p.ensureWS(ctx); err != nil {
+		return fmt.Errorf("ws connect for agent links: %w", err)
+	}
+
+	current, err := p.observeAgentLink(ctx, key)
+	if err != nil {
+		return err
+	}
+	if current == nil {
+		return fmt.Errorf("agent link %s not found for update", key)
+	}
+
+	linkID := strVal(current, "id")
+	if linkID == "" {
+		return fmt.Errorf("agent link %s: missing id", key)
+	}
+
+	patch := copyMap(spec)
+	// Source/target are immutable identity — drop if user included them.
+	delete(patch, "sourceAgent")
+	delete(patch, "targetAgent")
+	patch["linkId"] = linkID
+
+	if _, err := p.ws.Call(ctx, "agents.links.update", patch); err != nil {
+		return fmt.Errorf("agents.links.update %s: %w", key, err)
+	}
+	return nil
+}
+
+// deleteAgentLink removes an agent link via WS RPC. Idempotent.
+func (p *Provider) deleteAgentLink(ctx context.Context, key string) error {
+	if err := p.ensureWS(ctx); err != nil {
+		return fmt.Errorf("ws connect for agent links: %w", err)
+	}
+
+	current, err := p.observeAgentLink(ctx, key)
+	if err != nil {
+		// Treat agent-not-found as already-gone.
+		if strings.Contains(err.Error(), "not found") {
+			return nil
+		}
+		return err
+	}
+	if current == nil {
+		return nil
+	}
+
+	linkID := strVal(current, "id")
+	if linkID == "" {
+		return fmt.Errorf("agent link %s: missing id", key)
+	}
+
+	if _, err := p.ws.Call(ctx, "agents.links.delete", map[string]any{"linkId": linkID}); err != nil {
+		return fmt.Errorf("agents.links.delete %s: %w", key, err)
+	}
+	return nil
+}

--- a/internal/provider/goclaw/list_all.go
+++ b/internal/provider/goclaw/list_all.go
@@ -223,6 +223,89 @@ func (p *Provider) listAllSecureCLIs(ctx context.Context) ([]reconciler.Resource
 	return infos, nil
 }
 
+// listAllAgentLinks returns ResourceInfo for every agent link in GoClaw via WS RPC.
+// agents.links.list requires an agentId — there is no tenant-wide list endpoint.
+// Strategy: enumerate all agents in the tenant, list links from each as source
+// (direction=from), and emit one ResourceInfo per link with composite name
+// "sourceKey--targetKey". Each link has exactly one source so no dedup needed.
+// Skips links with team_id set — those are managed by the AgentTeam subsystem.
+func (p *Provider) listAllAgentLinks(ctx context.Context) ([]reconciler.ResourceInfo, error) {
+	if err := p.ensureWS(ctx); err != nil {
+		return nil, fmt.Errorf("ws connect for agent links: %w", err)
+	}
+
+	// Enumerate agents in tenant.
+	agentData, err := p.http.Get(ctx, "/v1/agents")
+	if err != nil {
+		return nil, fmt.Errorf("list agents: %w", err)
+	}
+	var agentResp struct {
+		Agents []map[string]any `json:"agents"`
+	}
+	if err := json.Unmarshal(agentData, &agentResp); err != nil {
+		return nil, fmt.Errorf("parse agents response: %w", err)
+	}
+
+	// Build agentID → agentKey map for translating target IDs back to keys.
+	keyByID := make(map[string]string, len(agentResp.Agents))
+	var sourceAgents []map[string]any
+	for _, a := range agentResp.Agents {
+		if !p.matchesTenant(ctx, a) {
+			continue
+		}
+		id := strVal(a, "id")
+		key := strVal(a, "agent_key")
+		if id == "" || key == "" {
+			continue
+		}
+		keyByID[id] = key
+		sourceAgents = append(sourceAgents, a)
+	}
+
+	infos := make([]reconciler.ResourceInfo, 0)
+	for _, a := range sourceAgents {
+		sourceID := strVal(a, "id")
+		sourceKey := strVal(a, "agent_key")
+
+		payload, err := p.ws.Call(ctx, "agents.links.list", map[string]any{
+			"agentId":   sourceID,
+			"direction": "from",
+		})
+		if err != nil {
+			return nil, fmt.Errorf("agents.links.list for %s: %w", sourceKey, err)
+		}
+		var resp struct {
+			Links []map[string]any `json:"links"`
+		}
+		if err := json.Unmarshal(payload, &resp); err != nil {
+			return nil, fmt.Errorf("parse agents.links.list response: %w", err)
+		}
+
+		for _, link := range resp.Links {
+			camel := translateResult(link)
+			// Skip team-managed links — owned by AgentTeam subsystem.
+			if tid := strVal(camel, "teamId"); tid != "" {
+				continue
+			}
+			targetID := strVal(camel, "targetAgentId")
+			targetKey := keyByID[targetID]
+			if targetKey == "" {
+				// Prefer the joined key if denormalized in the response; else skip.
+				targetKey = strVal(camel, "targetAgentKey")
+				if targetKey == "" {
+					continue
+				}
+			}
+			infos = append(infos, reconciler.ResourceInfo{
+				Kind:      manifest.KindAgentLink,
+				Name:      sourceKey + "--" + targetKey,
+				CreatedBy: strVal(camel, "createdBy"),
+			})
+		}
+	}
+	return infos, nil
+}
+
 // listAllTenants returns ResourceInfo for every tenant in GoClaw.
 func (p *Provider) listAllTenants(ctx context.Context) ([]reconciler.ResourceInfo, error) {
 	data, err := p.http.Get(ctx, "/v1/tenants")

--- a/internal/provider/goclaw/provider.go
+++ b/internal/provider/goclaw/provider.go
@@ -169,6 +169,8 @@ func (p *Provider) Observe(ctx context.Context, kind manifest.ResourceKind, key 
 		return p.observeSecureCLI(ctx, key)
 	case manifest.KindSecureCLIGrant:
 		return p.observeSecureCLIGrant(ctx, key)
+	case manifest.KindAgentLink:
+		return p.observeAgentLink(ctx, key)
 	default:
 		return nil, fmt.Errorf("observe not implemented for kind %s", kind)
 	}
@@ -238,6 +240,8 @@ func (p *Provider) Create(ctx context.Context, kind manifest.ResourceKind, key s
 		return p.createSecureCLI(ctx, key, spec)
 	case manifest.KindSecureCLIGrant:
 		return p.createSecureCLIGrant(ctx, key, spec)
+	case manifest.KindAgentLink:
+		return p.createAgentLink(ctx, key, spec)
 	default:
 		return fmt.Errorf("create not implemented for kind %s", kind)
 	}
@@ -274,6 +278,8 @@ func (p *Provider) Update(ctx context.Context, kind manifest.ResourceKind, key s
 		return p.updateSecureCLI(ctx, key, spec)
 	case manifest.KindSecureCLIGrant:
 		return p.updateSecureCLIGrant(ctx, key, spec)
+	case manifest.KindAgentLink:
+		return p.updateAgentLink(ctx, key, spec)
 	default:
 		return fmt.Errorf("update not implemented for kind %s", kind)
 	}
@@ -308,6 +314,8 @@ func (p *Provider) Delete(ctx context.Context, kind manifest.ResourceKind, key s
 		return p.deleteSecureCLI(ctx, key)
 	case manifest.KindSecureCLIGrant:
 		return p.deleteSecureCLIGrant(ctx, key)
+	case manifest.KindAgentLink:
+		return p.deleteAgentLink(ctx, key)
 	case manifest.KindSkill:
 		return nil // not deletable
 	default:
@@ -336,6 +344,8 @@ func (p *Provider) ListAll(ctx context.Context, kind manifest.ResourceKind) ([]r
 		return p.listAllTeams(ctx)
 	case manifest.KindSecureCLI:
 		return p.listAllSecureCLIs(ctx)
+	case manifest.KindAgentLink:
+		return p.listAllAgentLinks(ctx)
 	case manifest.KindBuiltinToolConfig, manifest.KindSkillConfig, manifest.KindSystemConfig, manifest.KindMCPCredentials, manifest.KindSecureCLIGrant:
 		return nil, nil // per-tenant configs and child resources not enumerable for prune
 	default:

--- a/internal/provider/goclaw/ws_test_helpers_test.go
+++ b/internal/provider/goclaw/ws_test_helpers_test.go
@@ -87,3 +87,66 @@ func newWSTestServer(t *testing.T, responses []wsResponse, httpRoutes http.Handl
 	return p, srv.Close
 }
 
+// newWSTestServerSmart is a variant of newWSTestServer that routes
+// agents.links.list calls based on the agentId parameter. Used to mock
+// realistic per-agent link enumeration. The handler also serves /v1/agents
+// from the provided agents slice.
+func newWSTestServerSmart(t *testing.T, agents []map[string]any, linksByAgentID map[string][]map[string]any) (*Provider, func()) {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/agents", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"agents": agents})
+	})
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for {
+			var req requestFrame
+			if err := conn.ReadJSON(&req); err != nil {
+				return
+			}
+			if req.Method == "connect" {
+				_ = conn.WriteJSON(responseFrame{Type: "res", ID: req.ID, OK: true})
+				continue
+			}
+			if req.Method != "agents.links.list" {
+				_ = conn.WriteJSON(responseFrame{
+					Type:  "res",
+					ID:    req.ID,
+					OK:    false,
+					Error: &rpcError{Message: "method not found: " + req.Method},
+				})
+				continue
+			}
+			// Parse agentId from params and look up the canned response.
+			paramsBytes, _ := json.Marshal(req.Params)
+			var params struct {
+				AgentID string `json:"agentId"`
+			}
+			_ = json.Unmarshal(paramsBytes, &params)
+			links := linksByAgentID[params.AgentID]
+			if links == nil {
+				links = []map[string]any{}
+			}
+			payload, _ := json.Marshal(map[string]any{"links": links})
+			_ = conn.WriteJSON(responseFrame{
+				Type:    "res",
+				ID:      req.ID,
+				OK:      true,
+				Payload: json.RawMessage(payload),
+			})
+		}
+	})
+
+	srv := httptest.NewServer(mux)
+	p := New(srv.URL, "test-token")
+	return p, srv.Close
+}
+

--- a/internal/reconciler/engine.go
+++ b/internal/reconciler/engine.go
@@ -344,6 +344,7 @@ func (e *Engine) stepCompare(_ context.Context, rc *reconcileContext) error {
 			rc.change.Forced = true
 		} else {
 			rc.change.Action = ActionNoop
+			e.warnBlindNoop(rc)
 		}
 		return nil
 	}
@@ -351,6 +352,41 @@ func (e *Engine) stepCompare(_ context.Context, rc *reconcileContext) error {
 	rc.change.Action = ActionUpdate
 	rc.change.Diff = diffs
 	return nil
+}
+
+// warnBlindNoop emits a WARN when a noop hides potential drift in write-only fields.
+// It fires when the desired spec contains at least one write-only field with a
+// non-trivial value (non-nil, non-empty map/slice). The reconciler cannot compare
+// those fields because the GoClaw list API does not return them.
+func (e *Engine) warnBlindNoop(rc *reconcileContext) {
+	blindFields := manifest.WriteOnlyFields(rc.resource.Kind)
+	var present []string
+	for _, field := range blindFields {
+		val, ok := rc.spec[field]
+		if !ok || val == nil {
+			continue
+		}
+		switch v := val.(type) {
+		case map[string]any:
+			if len(v) == 0 {
+				continue
+			}
+		case []any:
+			if len(v) == 0 {
+				continue
+			}
+		}
+		present = append(present, field)
+	}
+	if len(present) == 0 {
+		return
+	}
+	e.logger.Warn("resource no-op may hide drift in unobservable fields",
+		slog.String("kind", string(rc.resource.Kind)),
+		slog.String("name", rc.resource.Name),
+		slog.Any("unobservable_fields", present),
+		slog.String("hint", "this field is not returned by the GoClaw list API; the reconciler cannot detect drift in it. Force re-apply by toggling another observable field (e.g. enabled) or by deleting and re-creating the resource."),
+	)
 }
 
 func (e *Engine) execute(ctx context.Context, change Change, res manifest.Resource) error {

--- a/internal/reconciler/engine.go
+++ b/internal/reconciler/engine.go
@@ -344,7 +344,7 @@ func (e *Engine) stepCompare(_ context.Context, rc *reconcileContext) error {
 			rc.change.Forced = true
 		} else {
 			rc.change.Action = ActionNoop
-			e.warnBlindNoop(rc)
+			e.warnBlindNoop(rc, desiredHash, observedHash)
 		}
 		return nil
 	}
@@ -356,9 +356,18 @@ func (e *Engine) stepCompare(_ context.Context, rc *reconcileContext) error {
 
 // warnBlindNoop emits a WARN when a noop hides potential drift in write-only fields.
 // It fires when the desired spec contains at least one write-only field with a
-// non-trivial value (non-nil, non-empty map/slice). The reconciler cannot compare
-// those fields because the GoClaw list API does not return them.
-func (e *Engine) warnBlindNoop(rc *reconcileContext) {
+// non-trivial value (non-nil, non-empty map/slice/string). The reconciler cannot
+// compare those fields directly because the GoClaw list API does not return them.
+//
+// Suppressed when the write-only-hash mechanism conclusively proved no drift —
+// i.e., both desiredHash and observedHash are present and matched. In that case
+// the kind echoes a writeOnlyHash and we can trust the hash comparison; warning
+// would be spurious and would desensitize operators before they hit the real
+// silent-noop case the warning is designed to catch.
+func (e *Engine) warnBlindNoop(rc *reconcileContext, desiredHash, observedHash string) {
+	if desiredHash != "" && observedHash != "" {
+		return
+	}
 	blindFields := manifest.WriteOnlyFields(rc.resource.Kind)
 	var present []string
 	for _, field := range blindFields {
@@ -373,6 +382,10 @@ func (e *Engine) warnBlindNoop(rc *reconcileContext) {
 			}
 		case []any:
 			if len(v) == 0 {
+				continue
+			}
+		case string:
+			if v == "" {
 				continue
 			}
 		}

--- a/internal/reconciler/engine_test.go
+++ b/internal/reconciler/engine_test.go
@@ -1,8 +1,11 @@
 package reconciler
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -449,5 +452,175 @@ func TestReconcile_ParallelProducesSameResultAsSequential(t *testing.T) {
 	}
 	if len(seqPlan.Changes) != len(parPlan.Changes) {
 		t.Errorf("changes count mismatch: sequential=%d parallel=%d", len(seqPlan.Changes), len(parPlan.Changes))
+	}
+}
+
+// newTestLogger returns a slog.Logger backed by a buffer so tests can inspect output.
+func newTestLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func TestWarnBlindNoop_EmitsWarnWhenBlindFieldPresent(t *testing.T) {
+	// BuiltinToolConfig with settings (a blind field) — noop should emit WARN
+	provider := newMockProvider()
+	// Observed state has only "enabled" (what the list API returns)
+	provider.observed["BuiltinToolConfig/create-image"] = map[string]any{"enabled": true}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindBuiltinToolConfig,
+				Name: "create-image",
+				Spec: map[string]any{
+					"enabled": true,
+					"settings": map[string]any{
+						"providers": []any{"dashscope", "openai"},
+					},
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected 1 noop, got noops=%d updates=%d", plan.Noops, plan.Updates)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("expected blind-noop warning in log output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "settings") {
+		t.Errorf("expected 'settings' in warning log, got:\n%s", out)
+	}
+}
+
+func TestWarnBlindNoop_NoWarnWhenBlindFieldAbsent(t *testing.T) {
+	// BuiltinToolConfig without settings — noop should NOT warn
+	provider := newMockProvider()
+	provider.observed["BuiltinToolConfig/create-image"] = map[string]any{"enabled": true}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindBuiltinToolConfig,
+				Name: "create-image",
+				Spec: map[string]any{"enabled": true},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected 1 noop, got noops=%d", plan.Noops)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("unexpected blind-noop warning when blind field absent:\n%s", out)
+	}
+}
+
+func TestWarnBlindNoop_NoWarnWhenBlindFieldEmptyMap(t *testing.T) {
+	// settings present but empty — should NOT warn (trivial value)
+	provider := newMockProvider()
+	provider.observed["BuiltinToolConfig/create-image"] = map[string]any{"enabled": true}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindBuiltinToolConfig,
+				Name: "create-image",
+				Spec: map[string]any{
+					"enabled":  true,
+					"settings": map[string]any{},
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected 1 noop, got noops=%d", plan.Noops)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("unexpected blind-noop warning for empty map:\n%s", out)
+	}
+}
+
+func TestWarnBlindNoop_NoWarnOnCreate(t *testing.T) {
+	// Resource doesn't exist — action is create, not noop; should not warn
+	provider := newMockProvider()
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindBuiltinToolConfig,
+				Name: "create-image",
+				Spec: map[string]any{
+					"enabled": true,
+					"settings": map[string]any{"providers": []any{"dashscope"}},
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Creates != 1 {
+		t.Fatalf("expected 1 create, got creates=%d", plan.Creates)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("unexpected blind-noop warning on create:\n%s", out)
+	}
+}
+
+func TestWarnBlindNoop_GenericAcrossKinds(t *testing.T) {
+	// Provider with apiKey (blind field) — noop should warn
+	provider := newMockProvider()
+	provider.observed["Provider/anthropic"] = map[string]any{"displayName": "Anthropic"}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindProvider,
+				Name: "anthropic",
+				Spec: map[string]any{
+					"displayName": "Anthropic",
+					"apiKey":      "sk-secret-key",
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected 1 noop, got noops=%d updates=%d", plan.Noops, plan.Updates)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("expected blind-noop warning for Provider/apiKey, got:\n%s", out)
+	}
+	if !strings.Contains(out, "apiKey") {
+		t.Errorf("expected 'apiKey' in warning log, got:\n%s", out)
 	}
 }

--- a/internal/reconciler/engine_test.go
+++ b/internal/reconciler/engine_test.go
@@ -624,3 +624,104 @@ func TestWarnBlindNoop_GenericAcrossKinds(t *testing.T) {
 		t.Errorf("expected 'apiKey' in warning log, got:\n%s", out)
 	}
 }
+
+func TestWarnBlindNoop_NoWarnOnHashConfirmedNoop(t *testing.T) {
+	// Agent with contextFiles (a blind field) AND writeOnlyHash echoed by server
+	// → hash mechanism conclusively proved no drift → must NOT warn.
+	// Regression guard: without this suppression, every Agent reconcile would spam
+	// the warning every loop, defeating the PR's purpose.
+	spec := map[string]any{
+		"model":        "gpt-4",
+		"contextFiles": []any{map[string]any{"IDENTITY.md": "I am a bot"}},
+	}
+	woFields := manifest.WriteOnlyFields(manifest.KindAgent)
+	expectedHash := HashWriteOnlyFields(spec, woFields, nil)
+
+	provider := newMockProvider()
+	provider.observed["Agent/bot"] = map[string]any{
+		"model":         "gpt-4",
+		"writeOnlyHash": expectedHash,
+	}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{Kind: manifest.KindAgent, Name: "bot", Spec: spec},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected 1 noop (hash matches), got noops=%d updates=%d", plan.Noops, plan.Updates)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("unexpected blind-noop warning when hash mechanism proved no drift:\n%s", out)
+	}
+}
+
+func TestWarnBlindNoop_NoWarnWhenBlindFieldEmptyString(t *testing.T) {
+	// Provider with apiKey: "" — empty-string blind field → treat as trivial, no warn.
+	provider := newMockProvider()
+	provider.observed["Provider/anthropic"] = map[string]any{"displayName": "Anthropic"}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindProvider,
+				Name: "anthropic",
+				Spec: map[string]any{
+					"displayName": "Anthropic",
+					"apiKey":      "",
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected 1 noop, got noops=%d", plan.Noops)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("unexpected blind-noop warning for empty-string apiKey:\n%s", out)
+	}
+}
+
+func TestWarnBlindNoop_NoWarnOnForce(t *testing.T) {
+	// Force flag turns a would-be-noop into an update — warn must not fire.
+	provider := newMockProvider()
+	provider.observed["BuiltinToolConfig/create-image"] = map[string]any{"enabled": true}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindBuiltinToolConfig,
+				Name: "create-image",
+				Spec: map[string]any{
+					"enabled":  true,
+					"settings": map[string]any{"providers": []any{"dashscope"}},
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true, Force: true})
+	if plan.Updates != 1 {
+		t.Fatalf("expected 1 forced update, got updates=%d noops=%d", plan.Updates, plan.Noops)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "no-op may hide drift") {
+		t.Errorf("unexpected blind-noop warning on forced update:\n%s", out)
+	}
+}

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -719,6 +719,8 @@ var kindAliases = map[string]manifest.ResourceKind{
 	"systemconfig": manifest.KindSystemConfig,
 	"cli":          manifest.KindSecureCLI,
 	"securecli":    manifest.KindSecureCLI,
+	"link":         manifest.KindAgentLink,
+	"agentlink":    manifest.KindAgentLink,
 }
 
 // executeCommand processes : commands (kind switching, quit, etc.)

--- a/internal/tui/views/styles.go
+++ b/internal/tui/views/styles.go
@@ -97,6 +97,7 @@ var KindColor = map[manifest.ResourceKind]tcell.Color{
 	manifest.KindSystemConfig:      ColorRosewater,
 	manifest.KindSecureCLI:         ColorPink,
 	manifest.KindSecureCLIGrant:    ColorFlamingo,
+	manifest.KindAgentLink:         ColorSky,
 }
 
 // StatusCell returns a formatted status string with Unicode indicator and its color.


### PR DESCRIPTION
## Bundled scope

This PR contains **two features**, separated cleanly by commit:

1. **`91b25ed feat(manifest): add KindAgentLink`** — declarative agent delegation graph resource. New manifest kind, validation, provider implementation, list_all support, TUI affordance. +828 LOC across 12 files.
2. **`dec691c feat(reconciler): warn when no-op hides drift in unobservable fields`** + **`e25bc83 fix(reconciler): suppress warnBlindNoop on hash-confirmed noop`** — observability safety net. WARN log when reconciler decides noop but spec contains a write-only field with a non-trivial value AND the write-only-hash mechanism didn't already prove no drift. +209 LOC across 2 files.

Reviewers can read the two commits independently. The features are not coupled; bundling is for delivery convenience (PR #6 — the actual fix for the silent-noop bug — branched off this work and depends on the commit history here).

## Incident (motivating the warn feature)

Updated `BuiltinToolConfig` `create-image` in goclaw-config (added a new provider to the chain via `spec.settings.providers`). The gcplane serve reconciler reported `noops`. The cluster kept the old chain. 30 minutes of debugging later: `settings` was in the `KindBuiltinToolConfig` write-only field list, so drift detection stripped it from both observed and desired state before comparing → always equal → silent noop.

The fix for the underlying bug is in PR #6. **This PR is the safety net** — even after PR #6 lands, future fields with the same shape (write-only + silently-stripped + observable-state-not-returned) will surface immediately via WARN instead of needing a debug session.

## Warn feature design

When `stepCompare` decides `Action = Noop` AND the desired-state spec contains one or more keys from `manifest.WriteOnlyFields(kind)` with a non-trivial value (non-nil, non-empty map/slice/string), the reconciler emits:

```
WARN msg="resource no-op may hide drift in unobservable fields"
     kind=BuiltinToolConfig name=create-image
     unobservable_fields=[settings]
     hint="this field is not returned by the GoClaw list API; the reconciler cannot detect drift in it. Force re-apply by toggling another observable field (e.g. enabled) or by deleting and re-creating the resource."
```

**Suppression rules** (to keep this signal — not noise):
- Skipped when the write-only-hash mechanism conclusively proved no drift (`desiredHash != "" && observedHash != ""`). Without this, every Agent with `contextFiles` would warn every reconcile pass.
- Skipped on Create / Update / forced-Update paths (only Noop reaches the warn site).
- Skipped on `SyncPolicy: Ignore`.
- Skipped on `stepObserve` errors (only fires when observation succeeded).
- Trivial-value suppression: nil, missing key, empty map, empty slice, empty string.

## Tests

| Test | Covers |
|---|---|
| `TestWarnBlindNoop_EmitsWarnWhenBlindFieldPresent` | BuiltinToolConfig with settings → warn |
| `TestWarnBlindNoop_NoWarnWhenBlindFieldAbsent` | BuiltinToolConfig without settings → no warn |
| `TestWarnBlindNoop_NoWarnWhenBlindFieldEmptyMap` | settings: {} → no warn |
| `TestWarnBlindNoop_NoWarnWhenBlindFieldEmptyString` | apiKey: "" → no warn |
| `TestWarnBlindNoop_NoWarnOnCreate` | resource doesn't exist → no warn |
| `TestWarnBlindNoop_NoWarnOnForce` | force=true → no warn (path becomes Update) |
| `TestWarnBlindNoop_NoWarnOnHashConfirmedNoop` | **regression guard** — Agent with `contextFiles` + `writeOnlyHash` echoed → no warn |
| `TestWarnBlindNoop_GenericAcrossKinds` | Provider with apiKey → warn (proves loop is over the strip map, not hard-coded) |

## Files (warn feature)

- `internal/reconciler/engine.go` — `warnBlindNoop` method + call site
- `internal/reconciler/engine_test.go` — 8 unit tests

## Files (KindAgentLink feature)

- `internal/manifest/types.go`, `validate.go`, `validate_refs.go`, `validate_test.go`, `field_config.go`
- `internal/provider/goclaw/agent_links.go` (new), `agent_link_test.go` (new)
- `internal/provider/goclaw/list_all.go`, `provider.go`, `ws_test_helpers_test.go`
- `internal/tui/app.go`, `internal/tui/views/styles.go`

## Out of scope

- Fixing the underlying observability gap for `BuiltinToolConfig.settings` — that's PR #6.
- Auditing the `internalFields` filter (a separate strip mechanism) for completeness — separate task.

## Test plan
- [x] `go test ./...` clean
- [x] `go build ./...` clean
- [ ] CI lint / test / e2e / gitleaks / vuln green (vuln depends on PR #7 Go bump being on main — already merged)