### PR TITLE
fix(security): bump Go 1.25.9 → 1.25.10 to resolve 2 stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dataplanelabs/gcplane
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/gdamore/tcell/v2 v2.8.1


### PR DESCRIPTION
## Summary
Fixes the `vuln` workflow which has been failing on main since net@1.25.10 was published. Two stdlib CVEs trigger via paths actually used by gcplane:

- **GO-2026-4971** — panic in `net.Dial` / `net.LookupPort` on Windows with NUL byte. Reachable via `WSClient.Connect` (websocket dialer → net.Dialer.DialContext) and `server.ListenAndServe` (→ net.Listen).
- **GO-2026-4918** — infinite loop in HTTP/2 transport with bad SETTINGS_MAX_FRAME_SIZE. Reachable via `WebhookNotifier`, TUI `AttachClient.Healthcheck`, TUI `AttachClient.TriggerTenantSync`.

## Changes
- `go.mod` — `go 1.25.9` → `go 1.25.10`

That's it. Dockerfile already uses `golang:1.25-alpine` which floats to latest patch. CI workflows use `go-version-file: go.mod` so they pick up the bump automatically.

Follows the pattern of ad958a8 (`bump Go 1.25.8 → 1.25.9`).

## Test plan
- [x] `go build ./...` clean locally
- [ ] CI vuln check passes (the whole point of this PR)
- [ ] CI lint / test / e2e / gitleaks remain green