### PR TITLE
feat(reconciler): filesystem-driven skill sync

### DIFF
--- a/internal/manifest/field_config.go
+++ b/internal/manifest/field_config.go
@@ -20,7 +20,14 @@ var writeOnlyFields = map[ResourceKind][]string{
 	KindMCPServer:         {"grants"},
 	KindCronJob:           {"agentKey", "message"},
 	KindAgentTeam:         {"lead", "members", "displayName"},
-	KindSkill:             {},
+	KindSkill: {
+		// sourceDir is the local filesystem path used by gcplane to build the
+		// upload ZIP; goclaw never returns it.
+		"sourceDir",
+		// version is goclaw-assigned (auto-bumped on upload); excluded from diff
+		// so re-applying without code changes doesn't surface drift.
+		"version",
+	},
 	KindBuiltinToolConfig: {}, // settings are observable via tenant_settings in list response
 	KindSkillConfig:       {},
 	KindSystemConfig:      {},

--- a/internal/manifest/loader.go
+++ b/internal/manifest/loader.go
@@ -80,6 +80,11 @@ func loadDir(dir string) (*Manifest, error) {
 		if ext != ".yaml" && ext != ".yml" {
 			continue
 		}
+		// skill-overrides.yaml is loaded by the skill walker — skip here so it
+		// doesn't fail the manifest schema check.
+		if e.Name() == skillOverridesFile {
+			continue
+		}
 
 		m, err := loadFile(filepath.Join(dir, e.Name()))
 		if err != nil {
@@ -102,6 +107,21 @@ func loadDir(dir string) (*Manifest, error) {
 			seen[key] = true
 			merged.Resources = append(merged.Resources, r)
 		}
+	}
+
+	// Synthesize KindSkill/KindSkillConfig from the filesystem tree, then
+	// merge — conflict-checked against YAML-declared resources via `seen`.
+	skillRes, err := LoadSkillResources(dir)
+	if err != nil {
+		return nil, fmt.Errorf("load filesystem skills in %s: %w", dir, err)
+	}
+	for _, r := range skillRes {
+		key := string(r.Kind) + "/" + r.Name
+		if seen[key] {
+			return nil, fmt.Errorf("%s declared both in YAML and as filesystem skill — remove one (dir: %s)", key, dir)
+		}
+		seen[key] = true
+		merged.Resources = append(merged.Resources, r)
 	}
 
 	if err := ExpandComposites(merged); err != nil {

--- a/internal/manifest/skill_loader.go
+++ b/internal/manifest/skill_loader.go
@@ -1,0 +1,204 @@
+package manifest
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// systemTenant is the directory name that marks global (cross-tenant) skills.
+// _system/skills/<slug>/ becomes visibility=public; any other tenant directory
+// produces visibility=tenant skills.
+const systemTenant = "_system"
+
+// skillsSubdir is the conventional subdirectory under a tenant root where skill
+// directories live.
+const skillsSubdir = "skills"
+
+// skillOverridesFile is the conventional file under a tenant root that toggles
+// global skills on/off per tenant.
+const skillOverridesFile = "skill-overrides.yaml"
+
+// skillFrontmatter mirrors the SKILL.md frontmatter goclaw parses on upload.
+// Only `name` is strictly required by goclaw; `description` is strongly
+// recommended for searchability.
+type skillFrontmatter struct {
+	Name        string `yaml:"name"`
+	Description string `yaml:"description"`
+}
+
+// skillOverlay is loaded from an optional frontmatter.yaml co-located with
+// SKILL.md. It carries fields gcplane needs at apply time but that don't fit
+// inside SKILL.md's frontmatter (e.g. tags, status).
+type skillOverlay struct {
+	Tags   []string `yaml:"tags,omitempty"`
+	Status string   `yaml:"status,omitempty"`
+}
+
+// skillOverridesDoc is the schema of <tenant>/skill-overrides.yaml.
+type skillOverridesDoc struct {
+	Overrides map[string]struct {
+		Enabled bool `yaml:"enabled"`
+	} `yaml:"overrides"`
+}
+
+// LoadSkillResources walks dir for skill directories and a skill-overrides.yaml
+// file, returning synthesized KindSkill + KindSkillConfig resources.
+//
+// Layout:
+//
+//	<dir>/skills/<slug>/SKILL.md          → KindSkill (visibility derived from dir basename)
+//	<dir>/skills/<slug>/frontmatter.yaml  → optional overlay (tags, status)
+//	<dir>/skill-overrides.yaml            → KindSkillConfig per entry
+//
+// When the dir basename equals `_system`, synthesized skills are tagged
+// visibility=public; otherwise visibility=tenant.
+// Returns an empty slice (not nil) when no skills are found, for backward
+// compatibility with existing YAML-only deployments.
+func LoadSkillResources(dir string) ([]Resource, error) {
+	out := make([]Resource, 0)
+
+	scope := "tenant"
+	if filepath.Base(dir) == systemTenant {
+		scope = "global"
+	}
+
+	skillsDir := filepath.Join(dir, skillsSubdir)
+	if info, err := os.Stat(skillsDir); err == nil && info.IsDir() {
+		entries, err := os.ReadDir(skillsDir)
+		if err != nil {
+			return nil, fmt.Errorf("readdir %s: %w", skillsDir, err)
+		}
+		seen := make(map[string]string, len(entries))
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			if strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			skillDir := filepath.Join(skillsDir, e.Name())
+			res, err := loadSkillDir(skillDir, e.Name(), scope)
+			if err != nil {
+				return nil, err
+			}
+			if prior, dup := seen[res.Name]; dup {
+				return nil, fmt.Errorf("duplicate skill slug %q at %s and %s", res.Name, prior, skillDir)
+			}
+			seen[res.Name] = skillDir
+			out = append(out, res)
+		}
+	}
+
+	overridesPath := filepath.Join(dir, skillOverridesFile)
+	if data, err := os.ReadFile(overridesPath); err == nil {
+		var doc skillOverridesDoc
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", overridesPath, err)
+		}
+		for slug, ov := range doc.Overrides {
+			out = append(out, Resource{
+				Kind: KindSkillConfig,
+				Name: slug,
+				Spec: map[string]any{"enabled": ov.Enabled},
+			})
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read %s: %w", overridesPath, err)
+	}
+
+	return out, nil
+}
+
+func loadSkillDir(skillDir, slug, scope string) (Resource, error) {
+	skillMDPath := filepath.Join(skillDir, "SKILL.md")
+	mdBytes, err := os.ReadFile(skillMDPath)
+	if err != nil {
+		return Resource{}, fmt.Errorf("read %s: %w", skillMDPath, err)
+	}
+
+	fm, err := parseFrontmatter(mdBytes)
+	if err != nil {
+		return Resource{}, fmt.Errorf("%s: %w", skillMDPath, err)
+	}
+	if fm.Name == "" {
+		return Resource{}, fmt.Errorf("%s: frontmatter is missing required field 'name'", skillMDPath)
+	}
+
+	visibility := "tenant"
+	if scope == "global" {
+		visibility = "public"
+	}
+
+	spec := map[string]any{
+		"description": fm.Description,
+		"visibility":  visibility,
+		"sourceDir":   skillDir,
+	}
+
+	overlayPath := filepath.Join(skillDir, "frontmatter.yaml")
+	if data, err := os.ReadFile(overlayPath); err == nil {
+		var overlay skillOverlay
+		if err := yaml.Unmarshal(data, &overlay); err != nil {
+			return Resource{}, fmt.Errorf("%s: %w", overlayPath, err)
+		}
+		if overlay.Status != "" {
+			spec["status"] = overlay.Status
+		}
+		if len(overlay.Tags) > 0 {
+			tags := make([]any, len(overlay.Tags))
+			for i, t := range overlay.Tags {
+				tags[i] = t
+			}
+			spec["tags"] = tags
+		}
+	} else if !os.IsNotExist(err) {
+		return Resource{}, fmt.Errorf("read %s: %w", overlayPath, err)
+	}
+
+	return Resource{
+		Kind: KindSkill,
+		Name: slug,
+		Spec: spec,
+	}, nil
+}
+
+// parseFrontmatter extracts the YAML block delimited by leading and closing
+// `---` lines. The remaining body is discarded — gcplane doesn't inspect it,
+// goclaw re-parses the full SKILL.md on upload.
+func parseFrontmatter(content []byte) (skillFrontmatter, error) {
+	var fm skillFrontmatter
+
+	trimmed := bytes.TrimPrefix(content, []byte{0xEF, 0xBB, 0xBF}) // strip UTF-8 BOM
+	trimmed = bytes.TrimLeft(trimmed, " \t\r\n")
+	// Normalize CRLF → LF so fence detection is line-oriented on Windows files.
+	normalized := bytes.ReplaceAll(trimmed, []byte("\r\n"), []byte("\n"))
+
+	// Require the opening fence to occupy its own line: `---\n` (or `---` then EOF).
+	// Otherwise content like `---foo\n` would be mis-parsed.
+	if !bytes.HasPrefix(normalized, []byte("---\n")) && !bytes.Equal(normalized, []byte("---")) {
+		return fm, fmt.Errorf("SKILL.md must start with a '---' frontmatter fence on its own line")
+	}
+	rest := normalized[4:] // skip "---\n"
+
+	// Closing fence: a line containing exactly `---`.
+	closeIdx := bytes.Index(rest, []byte("\n---\n"))
+	if closeIdx < 0 {
+		// Allow trailing `---` with no newline (file ends right after fence).
+		if i := bytes.LastIndex(rest, []byte("\n---")); i >= 0 && i+4 == len(rest) {
+			closeIdx = i
+		} else {
+			return fm, fmt.Errorf("SKILL.md frontmatter is missing closing '---' fence")
+		}
+	}
+	block := rest[:closeIdx]
+
+	if err := yaml.Unmarshal(block, &fm); err != nil {
+		return fm, fmt.Errorf("parse frontmatter: %w", err)
+	}
+	return fm, nil
+}

--- a/internal/manifest/skill_loader_test.go
+++ b/internal/manifest/skill_loader_test.go
@@ -1,0 +1,165 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func writeSkill(t *testing.T, dir, slug, frontmatter string) {
+	t.Helper()
+	skillDir := filepath.Join(dir, "skills", slug)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(frontmatter), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+}
+
+func TestLoadSkillResources_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "say-hello", "---\nname: Say Hello\ndescription: greets the user\n---\nbody\n")
+
+	overrides := []byte("overrides:\n  global-foo:\n    enabled: false\n")
+	if err := os.WriteFile(filepath.Join(dir, "skill-overrides.yaml"), overrides, 0o644); err != nil {
+		t.Fatalf("write overrides: %v", err)
+	}
+
+	res, err := LoadSkillResources(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("expected 2 resources (1 skill + 1 override), got %d", len(res))
+	}
+
+	sort.Slice(res, func(i, j int) bool { return string(res[i].Kind) < string(res[j].Kind) })
+	if res[0].Kind != KindSkill || res[0].Name != "say-hello" {
+		t.Errorf("expected Skill say-hello first, got %s/%s", res[0].Kind, res[0].Name)
+	}
+	if res[0].Spec["visibility"] != "tenant" {
+		t.Errorf("expected visibility=tenant for non-system dir, got %v", res[0].Spec["visibility"])
+	}
+	if res[0].Spec["description"] != "greets the user" {
+		t.Errorf("description not parsed: %v", res[0].Spec["description"])
+	}
+	if _, ok := res[0].Spec["sourceDir"].(string); !ok {
+		t.Errorf("expected sourceDir to be set, got %v", res[0].Spec["sourceDir"])
+	}
+	if res[1].Kind != KindSkillConfig || res[1].Name != "global-foo" {
+		t.Errorf("expected SkillConfig global-foo, got %s/%s", res[1].Kind, res[1].Name)
+	}
+	if res[1].Spec["enabled"] != false {
+		t.Errorf("expected enabled=false in override, got %v", res[1].Spec["enabled"])
+	}
+}
+
+func TestLoadSkillResources_SystemDirYieldsPublicVisibility(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "_system")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writeSkill(t, dir, "global-greet", "---\nname: Global Greet\n---\n")
+
+	res, err := LoadSkillResources(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(res))
+	}
+	if res[0].Spec["visibility"] != "public" {
+		t.Errorf("expected visibility=public for _system, got %v", res[0].Spec["visibility"])
+	}
+}
+
+func TestLoadSkillResources_EmptyTreeNoError(t *testing.T) {
+	dir := t.TempDir() // no skills/ subdir at all
+	res, err := LoadSkillResources(dir)
+	if err != nil {
+		t.Fatalf("expected no error for empty tree, got: %v", err)
+	}
+	if len(res) != 0 {
+		t.Errorf("expected empty result, got %d", len(res))
+	}
+}
+
+func TestLoadSkillResources_MissingNameField(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "bad", "---\ndescription: no name\n---\n")
+
+	_, err := LoadSkillResources(dir)
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("expected error to mention 'name', got: %v", err)
+	}
+}
+
+func TestLoadSkillResources_FrontmatterOverlay(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "with-tags", "---\nname: With Tags\n---\n")
+
+	overlay := []byte("tags:\n  - alpha\n  - beta\nstatus: active\n")
+	if err := os.WriteFile(filepath.Join(dir, "skills", "with-tags", "frontmatter.yaml"), overlay, 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	res, err := LoadSkillResources(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if res[0].Spec["status"] != "active" {
+		t.Errorf("status overlay not applied: %v", res[0].Spec["status"])
+	}
+	tags, _ := res[0].Spec["tags"].([]any)
+	if len(tags) != 2 || tags[0] != "alpha" {
+		t.Errorf("tags overlay not applied: %v", res[0].Spec["tags"])
+	}
+}
+
+func TestLoadDir_YamlAndFilesystemConflict(t *testing.T) {
+	root := t.TempDir()
+	// YAML resource
+	yaml := []byte("apiVersion: gcplane.io/v1\nkind: Manifest\nmetadata:\n  name: t\nresources:\n  - kind: Skill\n    name: clash\n    spec: {}\n")
+	if err := os.WriteFile(filepath.Join(root, "manifest.yaml"), yaml, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Filesystem skill with same slug
+	writeSkill(t, root, "clash", "---\nname: Clash\n---\n")
+
+	_, err := loadDir(root)
+	if err == nil {
+		t.Fatal("expected conflict error")
+	}
+	if !strings.Contains(err.Error(), "filesystem skill") {
+		t.Errorf("expected 'filesystem skill' in error, got: %v", err)
+	}
+}
+
+func TestParseFrontmatter_CRLF(t *testing.T) {
+	content := []byte("---\r\nname: hi\r\n---\r\nbody\r\n")
+	fm, err := parseFrontmatter(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if fm.Name != "hi" {
+		t.Errorf("expected name=hi, got %q", fm.Name)
+	}
+}
+
+func TestParseFrontmatter_BOM(t *testing.T) {
+	content := append([]byte{0xEF, 0xBB, 0xBF}, []byte("---\nname: hi\n---\n")...)
+	fm, err := parseFrontmatter(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if fm.Name != "hi" {
+		t.Errorf("expected name=hi, got %q", fm.Name)
+	}
+}

--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -68,10 +68,58 @@ func Validate(m *Manifest) []error {
 		if r.Spec == nil {
 			errs = append(errs, fmt.Errorf("%s: spec is required for %s", prefix, uid))
 		}
+
+		if r.Kind == KindSkill {
+			errs = append(errs, validateSkillSpec(prefix, r.Spec)...)
+		}
 	}
 
 	// Cross-resource reference validation
 	errs = append(errs, validateReferences(m)...)
 
+	return errs
+}
+
+// Skill enum values mirror goclaw's DB CHECK constraints (see goclaw
+// internal/store/sqlitestore/schema.sql `skills` table). Keep in sync.
+var (
+	skillVisibilityValues = map[string]bool{"private": true, "internal": true, "public": true, "tenant": true}
+	skillStatusValues     = map[string]bool{"active": true, "archived": true, "deleted": true, "draft": true}
+)
+
+func validateSkillSpec(prefix string, spec map[string]any) []error {
+	if spec == nil {
+		return nil
+	}
+	var errs []error
+	if v, ok := spec["visibility"].(string); ok && v != "" {
+		if !skillVisibilityValues[v] {
+			errs = append(errs, fmt.Errorf("%s: spec.visibility %q must be one of [private internal public tenant]", prefix, v))
+		}
+	}
+	if s, ok := spec["status"].(string); ok && s != "" {
+		if !skillStatusValues[s] {
+			errs = append(errs, fmt.Errorf("%s: spec.status %q must be one of [active archived deleted draft]", prefix, s))
+		}
+	}
+	if tags, ok := spec["tags"]; ok && tags != nil {
+		list, isList := tags.([]any)
+		if !isList {
+			errs = append(errs, fmt.Errorf("%s: spec.tags must be a list of strings", prefix))
+		} else {
+			seen := make(map[string]bool, len(list))
+			for i, t := range list {
+				s, ok := t.(string)
+				if !ok {
+					errs = append(errs, fmt.Errorf("%s: spec.tags[%d] must be a string", prefix, i))
+					continue
+				}
+				if seen[s] {
+					errs = append(errs, fmt.Errorf("%s: spec.tags duplicate %q", prefix, s))
+				}
+				seen[s] = true
+			}
+		}
+	}
 	return errs
 }

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -347,3 +347,45 @@ func TestValidate_NewKinds(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate_SkillSpec(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    map[string]any
+		wantErr string
+	}{
+		{"valid full spec", map[string]any{"visibility": "tenant", "status": "active", "tags": []any{"a", "b"}}, ""},
+		{"empty spec ok", map[string]any{}, ""},
+		{"bad visibility", map[string]any{"visibility": "weird"}, "visibility"},
+		{"bad status", map[string]any{"status": "frozen"}, "status"},
+		{"tags not list", map[string]any{"tags": "single-string"}, "tags must be a list"},
+		{"tags duplicate", map[string]any{"tags": []any{"x", "x"}}, "duplicate"},
+		{"tags non-string", map[string]any{"tags": []any{"ok", 42}}, "must be a string"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manifest{
+				APIVersion: "gcplane.io/v1",
+				Kind:       "Manifest",
+				Resources: []Resource{
+					{Kind: KindSkill, Name: "my-skill", Spec: tc.spec},
+				},
+			}
+			errs := Validate(m)
+			if tc.wantErr == "" {
+				if len(errs) != 0 {
+					t.Errorf("expected no errors, got: %v", errs)
+				}
+				return
+			}
+			joined := ""
+			for _, e := range errs {
+				joined += e.Error() + "\n"
+			}
+			if !strings.Contains(joined, tc.wantErr) {
+				t.Errorf("expected error containing %q, got: %s", tc.wantErr, joined)
+			}
+		})
+	}
+}

--- a/internal/provider/goclaw/helpers.go
+++ b/internal/provider/goclaw/helpers.go
@@ -62,6 +62,11 @@ var internalFields = []string{
 	// Accounting & metadata
 	"frontmatter",
 	"agent_count", "has_credentials", "credentials",
+	// Skill-specific server-managed fields (not authored in manifests)
+	"file_path", "file_size", "file_hash", "path", "baseDir", "source",
+	"missing_deps", "deps", "is_system", "author",
+	// Skill tenant-config field — surfaced separately via KindSkillConfig
+	"tenant_enabled",
 }
 
 // stripInternal removes API-internal fields from an observed resource.

--- a/internal/provider/goclaw/http_client.go
+++ b/internal/provider/goclaw/http_client.go
@@ -80,6 +80,59 @@ func (c *HTTPClient) Delete(ctx context.Context, path string) error {
 	return err
 }
 
+// PostMultipart performs an authenticated POST with a multipart body.
+// Used for skill ZIP uploads. The default Content-Type set by do() (application/json)
+// is overridden via the contentType argument.
+func (c *HTTPClient) PostMultipart(ctx context.Context, path string, body io.Reader, contentType string) ([]byte, error) {
+	return c.doRaw(ctx, http.MethodPost, path, body, contentType)
+}
+
+func (c *HTTPClient) doRaw(ctx context.Context, method, path string, body io.Reader, contentType string) ([]byte, error) {
+	start := time.Now()
+	url := c.baseURL + path
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	req.Header.Set("Accept", "application/json")
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		c.logger.Warn("api.error",
+			slog.String("method", method),
+			slog.String("path", path),
+			slog.Any("error", err),
+			slog.Duration("duration", duration))
+		return nil, fmt.Errorf("http %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	const maxResponseSize = 10 << 20
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseSize))
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	c.logger.Debug("api.response",
+		slog.String("method", method),
+		slog.String("path", path),
+		slog.Int("status", resp.StatusCode),
+		slog.Duration("duration", duration))
+
+	if err := classifyStatus(resp.StatusCode, respBody); err != nil {
+		return nil, err
+	}
+	return respBody, nil
+}
+
 func (c *HTTPClient) doJSON(ctx context.Context, method, path string, body any) ([]byte, error) {
 	data, err := json.Marshal(body)
 	if err != nil {

--- a/internal/provider/goclaw/provider.go
+++ b/internal/provider/goclaw/provider.go
@@ -224,6 +224,8 @@ func (p *Provider) Create(ctx context.Context, kind manifest.ResourceKind, key s
 		return p.createChannelInstance(ctx, key, spec)
 	case manifest.KindMCPServer:
 		return p.createMCPServer(ctx, key, spec)
+	case manifest.KindSkill:
+		return p.createSkill(ctx, key, spec)
 	case manifest.KindCronJob:
 		return p.createCronJob(ctx, key, spec)
 	case manifest.KindAgentTeam:
@@ -317,7 +319,7 @@ func (p *Provider) Delete(ctx context.Context, kind manifest.ResourceKind, key s
 	case manifest.KindAgentLink:
 		return p.deleteAgentLink(ctx, key)
 	case manifest.KindSkill:
-		return nil // not deletable
+		return p.deleteSkill(ctx, key)
 	default:
 		return fmt.Errorf("delete not implemented for kind %s", kind)
 	}

--- a/internal/provider/goclaw/skill_configs.go
+++ b/internal/provider/goclaw/skill_configs.go
@@ -8,6 +8,11 @@ import (
 
 // observeSkillConfig checks if a skill has a tenant-level config override.
 // Key is the skill slug.
+//
+// goclaw's GET /v1/skills returns a flat `tenant_enabled` field per skill when
+// the caller is tenant-scoped. The field is a JSON-null when no override exists,
+// and a bool (true/false) when an override is present. We exploit the nil-ness
+// of the unmarshalled pointer to distinguish "no override" from "explicit value".
 func (p *Provider) observeSkillConfig(ctx context.Context, key string) (map[string]any, error) {
 	data, err := p.http.Get(ctx, "/v1/skills")
 	if err != nil {
@@ -22,13 +27,19 @@ func (p *Provider) observeSkillConfig(ctx context.Context, key string) (map[stri
 	}
 
 	for _, s := range resp.Skills {
-		if strVal(s, "slug") == key {
-			if tc, ok := s["tenant_config"].(map[string]any); ok {
-				return translateResult(tc), nil
-			}
-			// Skill exists but no tenant config — return nil so reconciler creates it
+		if strVal(s, "slug") != key {
+			continue
+		}
+		raw, present := s["tenant_enabled"]
+		if !present || raw == nil {
+			// Field absent or JSON null → no tenant override
 			return nil, nil
 		}
+		enabled, ok := raw.(bool)
+		if !ok {
+			return nil, fmt.Errorf("skill %q: tenant_enabled has unexpected type %T", key, raw)
+		}
+		return translateResult(map[string]any{"enabled": enabled}), nil
 	}
 	return nil, nil
 }

--- a/internal/provider/goclaw/skill_configs_test.go
+++ b/internal/provider/goclaw/skill_configs_test.go
@@ -9,55 +9,63 @@ import (
 	"github.com/dataplanelabs/gcplane/internal/manifest"
 )
 
-func TestSkillConfig_Observe_WithTenantConfig(t *testing.T) {
-	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/v1/skills" {
-			json.NewEncoder(w).Encode(map[string]any{
-				"skills": []map[string]any{
-					{
-						"id": "uuid-1", "slug": "my-skill", "enabled": true,
-						"tenant_config": map[string]any{"enabled": false},
-					},
-				},
-			})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer cleanup()
+func TestSkillConfig_Observe(t *testing.T) {
+	tests := []struct {
+		name        string
+		skillRow    map[string]any
+		wantNil     bool
+		wantEnabled any
+	}{
+		{
+			name:     "no tenant override (field absent)",
+			skillRow: map[string]any{"id": "uuid-1", "slug": "my-skill", "enabled": true},
+			wantNil:  true,
+		},
+		{
+			name:     "no tenant override (field null)",
+			skillRow: map[string]any{"id": "uuid-1", "slug": "my-skill", "enabled": true, "tenant_enabled": nil},
+			wantNil:  true,
+		},
+		{
+			name:        "tenant override = true",
+			skillRow:    map[string]any{"id": "uuid-1", "slug": "my-skill", "enabled": true, "tenant_enabled": true},
+			wantEnabled: true,
+		},
+		{
+			name:        "tenant override = false",
+			skillRow:    map[string]any{"id": "uuid-1", "slug": "my-skill", "enabled": true, "tenant_enabled": false},
+			wantEnabled: false,
+		},
+	}
 
-	result, err := p.Observe(context.Background(), manifest.KindSkillConfig, "my-skill")
-	if err != nil {
-		t.Fatalf("observe: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result for skill with tenant config")
-	}
-	if result["enabled"] != false {
-		t.Errorf("expected enabled=false (tenant override), got %v", result["enabled"])
-	}
-}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodGet && r.URL.Path == "/v1/skills" {
+					json.NewEncoder(w).Encode(map[string]any{"skills": []map[string]any{tc.skillRow}})
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+			defer cleanup()
 
-func TestSkillConfig_Observe_NoTenantConfig(t *testing.T) {
-	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet && r.URL.Path == "/v1/skills" {
-			json.NewEncoder(w).Encode(map[string]any{
-				"skills": []map[string]any{
-					{"id": "uuid-1", "slug": "my-skill", "enabled": true},
-				},
-			})
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer cleanup()
-
-	result, err := p.Observe(context.Background(), manifest.KindSkillConfig, "my-skill")
-	if err != nil {
-		t.Fatalf("observe: %v", err)
-	}
-	if result != nil {
-		t.Fatalf("expected nil for skill without tenant config, got %v", result)
+			result, err := p.Observe(context.Background(), manifest.KindSkillConfig, "my-skill")
+			if err != nil {
+				t.Fatalf("observe: %v", err)
+			}
+			if tc.wantNil {
+				if result != nil {
+					t.Fatalf("expected nil, got %v", result)
+				}
+				return
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if result["enabled"] != tc.wantEnabled {
+				t.Errorf("enabled: want %v, got %v", tc.wantEnabled, result["enabled"])
+			}
+		})
 	}
 }
 

--- a/internal/provider/goclaw/skill_test.go
+++ b/internal/provider/goclaw/skill_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dataplanelabs/gcplane/internal/manifest"
@@ -50,7 +53,7 @@ func TestSkill_Observe_NotFound(t *testing.T) {
 	}
 }
 
-func TestSkill_Update(t *testing.T) {
+func TestSkill_Update_FiltersToWritableFields(t *testing.T) {
 	var putBody map[string]any
 
 	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -58,7 +61,7 @@ func TestSkill_Update(t *testing.T) {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/skills":
 			json.NewEncoder(w).Encode(map[string]any{
 				"skills": []map[string]any{
-					{"id": "s-uuid", "key": "web-search", "slug": "web-search"},
+					{"id": "s-uuid", "slug": "web-search"},
 				},
 			})
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/skills/s-uuid":
@@ -71,29 +74,160 @@ func TestSkill_Update(t *testing.T) {
 	}))
 	defer cleanup()
 
-	err := p.Update(context.Background(), manifest.KindSkill, "web-search", map[string]any{"enabled": false})
-	if err != nil {
+	spec := map[string]any{
+		"description": "updated desc",
+		"visibility":  "tenant",
+		"tags":        []any{"a", "b"},
+		"status":      "active",
+		"version":     7,
+		// Observed-only / forbidden fields — must be filtered out:
+		"enabled":     false,
+		"isSystem":    true,
+		"missingDeps": []any{"foo"},
+		"filePath":    "/etc/whatever",
+	}
+	if err := p.Update(context.Background(), manifest.KindSkill, "web-search", spec); err != nil {
 		t.Fatalf("update: %v", err)
 	}
-	if putBody["enabled"] != false {
-		t.Errorf("expected enabled=false, got %v", putBody["enabled"])
+
+	mustHave := []string{"description", "visibility", "tags", "status", "version"}
+	for _, k := range mustHave {
+		if _, ok := putBody[k]; !ok {
+			t.Errorf("expected PUT body to contain %q, got %v", k, putBody)
+		}
+	}
+	mustNotHave := []string{"enabled", "is_system", "missing_deps", "file_path"}
+	for _, k := range mustNotHave {
+		if _, ok := putBody[k]; ok {
+			t.Errorf("expected PUT body to OMIT %q, got %v", k, putBody)
+		}
 	}
 }
 
-// Skills are not deletable — Delete should return nil without calling any endpoint.
-func TestSkill_Delete_Noop(t *testing.T) {
-	called := false
+func TestSkill_Observe_MatchesBySlug(t *testing.T) {
 	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		called = true
-		w.WriteHeader(http.StatusInternalServerError)
+		json.NewEncoder(w).Encode(map[string]any{
+			"skills": []map[string]any{
+				{
+					"id":          "s1",
+					"slug":        "web-search",
+					"name":        "Web Search",
+					"description": "Search the web",
+					"visibility":  "public",
+					"version":     3,
+					"tags":        []string{"net", "fetch"},
+					"file_path":   "/tmp/should-be-stripped",
+				},
+			},
+		})
 	}))
 	defer cleanup()
 
-	if err := p.Delete(context.Background(), manifest.KindSkill, "web-search"); err != nil {
-		t.Fatalf("expected no-op delete to succeed, got: %v", err)
+	result, err := p.Observe(context.Background(), manifest.KindSkill, "web-search")
+	if err != nil {
+		t.Fatalf("observe: %v", err)
 	}
-	if called {
-		t.Error("expected no HTTP calls for skill delete")
+	if result == nil {
+		t.Fatal("expected non-nil")
+	}
+	if result["slug"] != "web-search" {
+		t.Errorf("missing slug, got %v", result)
+	}
+	if _, leaked := result["filePath"]; leaked {
+		t.Errorf("file_path leaked into observed result: %v", result)
+	}
+	if _, leaked := result["missingDeps"]; leaked {
+		t.Errorf("missing_deps leaked into observed result: %v", result)
+	}
+}
+
+func TestSkill_Delete_AlreadyAbsent(t *testing.T) {
+	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"skills": []map[string]any{}})
+	}))
+	defer cleanup()
+
+	if err := p.Delete(context.Background(), manifest.KindSkill, "missing"); err != nil {
+		t.Fatalf("expected idempotent delete of absent skill, got: %v", err)
+	}
+}
+
+func TestSkill_Delete_CallsAPI(t *testing.T) {
+	deleted := false
+	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/skills":
+			json.NewEncoder(w).Encode(map[string]any{
+				"skills": []map[string]any{{"id": "uuid-doom", "slug": "to-delete"}},
+			})
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/skills/uuid-doom":
+			deleted = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer cleanup()
+
+	if err := p.Delete(context.Background(), manifest.KindSkill, "to-delete"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if !deleted {
+		t.Error("expected DELETE /v1/skills/uuid-doom")
+	}
+}
+
+func TestSkill_Create_MissingSourceDir(t *testing.T) {
+	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer cleanup()
+
+	err := p.Create(context.Background(), manifest.KindSkill, "no-source", map[string]any{
+		"description": "missing sourceDir",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing sourceDir")
+	}
+}
+
+func TestSkill_Create_UploadsZIP(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: Test Skill\ndescription: hi\n---\nbody\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	gotMultipart := false
+	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/skills/upload" {
+			ct := r.Header.Get("Content-Type")
+			if !strings.HasPrefix(ct, "multipart/form-data") {
+				t.Errorf("expected multipart Content-Type, got %q", ct)
+			}
+			if err := r.ParseMultipartForm(8 << 20); err != nil {
+				t.Errorf("parse multipart: %v", err)
+			}
+			if _, _, err := r.FormFile("file"); err != nil {
+				t.Errorf("expected 'file' form part: %v", err)
+			} else {
+				gotMultipart = true
+			}
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{"slug": "test-skill", "version": 1})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer cleanup()
+
+	err := p.Create(context.Background(), manifest.KindSkill, "test-skill", map[string]any{
+		"sourceDir": dir,
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !gotMultipart {
+		t.Error("server never saw a multipart upload")
 	}
 }
 

--- a/internal/provider/goclaw/skills.go
+++ b/internal/provider/goclaw/skills.go
@@ -1,12 +1,36 @@
 package goclaw
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"mime/multipart"
+
+	"github.com/dataplanelabs/gcplane/internal/skillpkg"
 )
 
-// observeSkill fetches a skill by key from GoClaw.
+// ErrSkillSourceMissing is returned when a KindSkill create has no
+// sourceDir field — gcplane has nothing to upload.
+var ErrSkillSourceMissing = errors.New("KindSkill spec must include sourceDir (path to a directory containing SKILL.md)")
+
+// skillWritableFields lists the field names (camelCase) that gcplane sends
+// to PUT /v1/skills/{id}. goclaw strips id/owner_id/file_path/is_system/enabled
+// server-side; the toggle endpoint owns the `enabled` flip. Version, tags,
+// visibility, status, description, and name are accepted by the update handler.
+var skillWritableFields = map[string]struct{}{
+	"description": {},
+	"visibility":  {},
+	"status":      {},
+	"tags":        {},
+	"version":     {},
+	"name":        {},
+}
+
+// observeSkill fetches a skill by slug from GoClaw.
+// goclaw's list response keys skills by `slug`; the older code matched on
+// `key`, which never resolved against a real backend.
 func (p *Provider) observeSkill(ctx context.Context, key string) (map[string]any, error) {
 	data, err := p.http.Get(ctx, "/v1/skills")
 	if err != nil {
@@ -21,15 +45,101 @@ func (p *Provider) observeSkill(ctx context.Context, key string) (map[string]any
 	}
 
 	for _, s := range resp.Skills {
-		if strVal(s, "key") == key && p.matchesTenant(ctx, s) {
+		if matchSkillKey(s, key) && p.matchesTenant(ctx, s) {
 			return translateResult(stripInternal(s)), nil
 		}
 	}
 	return nil, nil
 }
 
+// matchSkillKey accepts a row keyed by either `slug` (canonical) or `key`
+// (legacy test fixtures); real goclaw responses always carry `slug`.
+func matchSkillKey(row map[string]any, key string) bool {
+	if strVal(row, "slug") == key {
+		return true
+	}
+	return strVal(row, "key") == key
+}
+
+// createSkill uploads a skill ZIP built from spec["sourceDir"] to
+// POST /v1/skills/upload. goclaw parses SKILL.md frontmatter to derive
+// slug, name, description — gcplane doesn't pass those as form fields.
+// Idempotent server-side: re-uploading identical content returns
+// status:"unchanged" without bumping the version.
+func (p *Provider) createSkill(ctx context.Context, key string, spec map[string]any) error {
+	sourceDir, _ := spec["sourceDir"].(string)
+	if sourceDir == "" {
+		return fmt.Errorf("skill %s: %w", key, ErrSkillSourceMissing)
+	}
+
+	pkg, err := skillpkg.PackDir(sourceDir)
+	if err != nil {
+		return fmt.Errorf("pack skill %s: %w", key, err)
+	}
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("file", key+".zip")
+	if err != nil {
+		return fmt.Errorf("multipart create: %w", err)
+	}
+	if _, err := fw.Write(pkg.ZIP); err != nil {
+		return fmt.Errorf("multipart write: %w", err)
+	}
+	if err := mw.Close(); err != nil {
+		return fmt.Errorf("multipart close: %w", err)
+	}
+
+	_, err = p.http.PostMultipart(ctx, "/v1/skills/upload", &buf, mw.FormDataContentType())
+	if err != nil {
+		return fmt.Errorf("upload skill %s: %w", key, err)
+	}
+
+	// goclaw extracts name/description/slug from SKILL.md frontmatter on
+	// upload but hardcodes visibility="internal" and ignores tags/status
+	// (handleUpload only reads the `file` form field). To honour the
+	// manifest's overlay fields, follow up with a PUT that sends just the
+	// writable subset. Skip the PUT when there are no overlay fields to
+	// avoid a wasted round-trip.
+	if hasOverlay(spec) {
+		if err := p.updateSkill(ctx, key, spec); err != nil {
+			return fmt.Errorf("apply overlay to skill %s after upload: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// hasOverlay returns true when spec carries any field that requires a
+// post-upload PUT (visibility/tags/status/description override).
+func hasOverlay(spec map[string]any) bool {
+	for k := range skillWritableFields {
+		if v, ok := spec[k]; ok && v != nil && v != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// deleteSkill removes a skill via DELETE /v1/skills/{id}.
+// Looks up the UUID via the existing list endpoint.
+func (p *Provider) deleteSkill(ctx context.Context, key string) error {
+	current, err := p.observeSkill(ctx, key)
+	if err != nil {
+		return err
+	}
+	if current == nil {
+		return nil // idempotent — already absent
+	}
+	id, ok := current["id"].(string)
+	if !ok || id == "" {
+		return fmt.Errorf("skill %s: missing id in observed result", key)
+	}
+	return p.http.Delete(ctx, "/v1/skills/"+id)
+}
+
 // updateSkill updates an existing skill in GoClaw.
-// Skills are auto-discovered; only update is supported.
+// Sends only writable fields; observed-only fields (version, etc.) are
+// allowed through but goclaw will accept or ignore them.
 func (p *Provider) updateSkill(ctx context.Context, key string, spec map[string]any) error {
 	current, err := p.observeSkill(ctx, key)
 	if err != nil {
@@ -44,7 +154,13 @@ func (p *Provider) updateSkill(ctx context.Context, key string, spec map[string]
 		return fmt.Errorf("skill %s: missing id", key)
 	}
 
-	body := translateSpec(spec)
+	writable := make(map[string]any, len(spec))
+	for k, v := range spec {
+		if _, ok := skillWritableFields[k]; ok {
+			writable[k] = v
+		}
+	}
+	body := translateSpec(writable)
 	_, err = p.http.Put(ctx, "/v1/skills/"+id, body)
 	return err
 }

--- a/internal/skillpkg/skillpkg.go
+++ b/internal/skillpkg/skillpkg.go
@@ -1,0 +1,134 @@
+// Package skillpkg builds deterministic ZIP archives from on-disk skill
+// directories. The output is byte-for-byte stable across runs: sorted file
+// paths, zeroed timestamps, fixed mode bits. Stability lets callers SHA-256
+// the archive as a content version.
+package skillpkg
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SkillFiles is the canonical filename for a skill's entrypoint.
+const SkillFilename = "SKILL.md"
+
+// MaxFileSize caps any single file inside a skill ZIP at 4 MiB.
+// Large binaries belong in package managers, not skills.
+const MaxFileSize = 4 << 20
+
+// PackResult captures the build output.
+type PackResult struct {
+	ZIP         []byte // ZIP archive contents
+	ContentHash string // SHA-256 of the archive (hex)
+	SkillMD     string // contents of SKILL.md (UTF-8)
+}
+
+// PackDir walks dir (must contain SKILL.md at its root), packs every regular
+// file into a deterministic ZIP, and returns the archive + content hash.
+// Symlinks, hidden files (.git, .DS_Store, etc.), and oversize files are
+// skipped to keep uploads safe.
+func PackDir(dir string) (*PackResult, error) {
+	skillPath := filepath.Join(dir, SkillFilename)
+	skillBytes, err := os.ReadFile(skillPath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", SkillFilename, err)
+	}
+
+	files, err := collectFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(files)
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	for _, rel := range files {
+		abs := filepath.Join(dir, rel)
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", rel, err)
+		}
+		if int64(len(data)) > MaxFileSize {
+			return nil, fmt.Errorf("%s exceeds %d bytes", rel, MaxFileSize)
+		}
+		fh := &zip.FileHeader{
+			Name:   filepath.ToSlash(rel),
+			Method: zip.Deflate,
+		}
+		// Zero out time so identical content always hashes the same.
+		fh.SetMode(0o644)
+		w, err := zw.CreateHeader(fh)
+		if err != nil {
+			return nil, fmt.Errorf("zip create %s: %w", rel, err)
+		}
+		if _, err := io.Copy(w, bytes.NewReader(data)); err != nil {
+			return nil, fmt.Errorf("zip write %s: %w", rel, err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("zip close: %w", err)
+	}
+
+	sum := sha256.Sum256(buf.Bytes())
+	return &PackResult{
+		ZIP:         buf.Bytes(),
+		ContentHash: hex.EncodeToString(sum[:]),
+		SkillMD:     string(skillBytes),
+	}, nil
+}
+
+func collectFiles(root string) ([]string, error) {
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if isSkippedDir(d.Name()) && path != root {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() {
+			return nil // skip symlinks, devices, etc.
+		}
+		if isSkippedFile(d.Name()) {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		out = append(out, rel)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walk %s: %w", root, err)
+	}
+	return out, nil
+}
+
+func isSkippedDir(name string) bool {
+	switch name {
+	case ".git", ".github", "node_modules", "__pycache__", ".venv", "venv":
+		return true
+	}
+	return strings.HasPrefix(name, ".")
+}
+
+func isSkippedFile(name string) bool {
+	switch name {
+	case ".DS_Store", "Thumbs.db", ".gitkeep", ".gitignore":
+		return true
+	}
+	return strings.HasPrefix(name, ".")
+}

--- a/internal/skillpkg/skillpkg_test.go
+++ b/internal/skillpkg/skillpkg_test.go
@@ -1,0 +1,83 @@
+package skillpkg
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestPackDir_BasicSkill(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: foo\n---\nbody\n")
+	writeFile(t, filepath.Join(dir, "scripts", "run.sh"), "#!/bin/sh\necho hi\n")
+	writeFile(t, filepath.Join(dir, ".DS_Store"), "junk") // skipped
+	writeFile(t, filepath.Join(dir, ".git", "HEAD"), "junk") // skipped
+
+	res, err := PackDir(dir)
+	if err != nil {
+		t.Fatalf("PackDir: %v", err)
+	}
+	if res.SkillMD == "" {
+		t.Error("SkillMD empty")
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(res.ZIP), int64(len(res.ZIP)))
+	if err != nil {
+		t.Fatalf("zip read: %v", err)
+	}
+	names := make(map[string]bool, len(zr.File))
+	for _, f := range zr.File {
+		names[f.Name] = true
+	}
+	want := []string{"SKILL.md", "scripts/run.sh"}
+	for _, n := range want {
+		if !names[n] {
+			t.Errorf("missing %q in zip; got %v", n, names)
+		}
+	}
+	if names[".DS_Store"] || names[".git/HEAD"] {
+		t.Errorf("hidden files leaked into zip: %v", names)
+	}
+}
+
+func TestPackDir_Deterministic(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "SKILL.md"), "---\nname: foo\n---\n")
+	writeFile(t, filepath.Join(dir, "b.txt"), "b")
+	writeFile(t, filepath.Join(dir, "a.txt"), "a")
+
+	r1, err := PackDir(dir)
+	if err != nil {
+		t.Fatalf("first pack: %v", err)
+	}
+	r2, err := PackDir(dir)
+	if err != nil {
+		t.Fatalf("second pack: %v", err)
+	}
+	if !bytes.Equal(r1.ZIP, r2.ZIP) {
+		t.Error("zip bytes differ between runs — packer is not deterministic")
+	}
+	if r1.ContentHash != r2.ContentHash {
+		t.Errorf("hash differs: %s vs %s", r1.ContentHash, r2.ContentHash)
+	}
+}
+
+func TestPackDir_MissingSkillMD(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "other.txt"), "x")
+	if _, err := PackDir(dir); err == nil {
+		t.Fatal("expected error for missing SKILL.md")
+	}
+}


### PR DESCRIPTION
## Summary

Discover `SKILL.md` directories under `<tenant>/skills/` and `_system/skills/`, package each as a deterministic ZIP, upload to goclaw, and apply manifest overlay fields with a follow-up PUT. Lets operators author skills as plain directories alongside the rest of their tenant config and have gcplane sync them on `apply`.

Closes gaps in two stacked plans:
- `plans/260520-1602-gcplane-skill-gap-closure/` — phases 1, 2, 4
- `plans/260520-1616-filesystem-driven-skills/` — phases 1, 2

## Changes

- **`internal/skillpkg/`** (new) — deterministic ZIP builder (sorted entries, zero mtime, hidden-file skip). Byte-stable across runs.
- **`internal/manifest/skill_loader.go`** (new) — filesystem walker. Parses `SKILL.md` frontmatter + optional `frontmatter.yaml` overlay + `skill-overrides.yaml`. Synthesized `KindSkill` / `KindSkillConfig` resources flow through the same validation + ordering pipeline as YAML resources. Conflict-checks against YAML-declared resources.
- **`internal/manifest/loader.go`** — wires the walker into `loadDir`; skips `skill-overrides.yaml` from YAML manifest parsing.
- **`internal/provider/goclaw/skills.go`** — `createSkill` builds multipart upload from `spec.sourceDir`, then PUTs overlay fields (goclaw hardcodes `visibility=internal` on upload and ignores form fields besides `file`). `deleteSkill` calls real `DELETE /v1/skills/{id}` instead of silent no-op. `observeSkill` matches by `slug` (was broken `key`). `updateSkill` filters to writable fields only.
- **`internal/provider/goclaw/skill_configs.go`** — replace nested `tenant_config` lookup with flat `tenant_enabled *bool` per goclaw's actual response shape (was producing drift loops).
- **`internal/provider/goclaw/http_client.go`** — `PostMultipart` helper.
- **`internal/manifest/validate.go`** — skill `visibility` / `status` enum validation, `tags` shape check.

## Authoring layout

```
<tenant>/
├── manifest.yaml
├── skills/
│   └── <slug>/
│       ├── SKILL.md          # required, with YAML frontmatter
│       └── frontmatter.yaml  # optional overlay: tags, status
└── skill-overrides.yaml      # optional: toggle global skills per tenant
```

## Test plan

- [x] `go test ./internal/...` — all packages pass
- [x] Code-reviewer subagent pass — addressed: tightened frontmatter fence check, createSkill follow-up PUT for overlay fields
- [ ] Apply against live goclaw with `annhien/skills/{chao-mung,nhac-viec-hang-ngay}` (goclaw-config side, separate PR)
- [ ] Confirm uploaded skills land with `visibility=tenant`

## Deferred (out of MVP)

- **Hard-delete with owner marker** — goclaw's `GET /v1/skills` doesn't expose `owner_id`, so gcplane can't safely distinguish UI-uploaded vs gcplane-uploaded skills. Needs a goclaw-side change first.
- **Client-side content-hash dedup** — goclaw already dedupes server-side by SHA-256 of SKILL.md. Client-side hashing is a bandwidth optimization, not a correctness fix.
- **Skill grants reconciliation** (`KindSkillAgentGrant` / `KindSkillUserGrant`) — orthogonal to content sync; defer until a tenant needs declarative grant management.
- **N+1 `GET /v1/skills`** — pre-existing; each observe walks the full list. Worth a follow-up once tenant skill counts grow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Skills can now be declared in filesystem format using SKILL.md files and directory structures
  * Added support for uploading skill source directories during creation
  * Implemented skill deletion functionality
  * Enabled skill configuration overrides through dedicated YAML files
  * Added validation for skill visibility, status, and tags properties

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dataplanelabs/gcplane/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->