### PR TITLE
feat(reconciler): auto-heal empty observedHash for supported kinds

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,10 @@ on:
     branches: [main]
 
 env:
-  GOCLAW_VERSION: "full"  # floating tag → v3.x (currently v3.1.1)
+  # latest-full tracks the dataplanelabs/goclaw fork's main branch (includes
+  # our migrations like 000060 write_only_hash that aren't yet upstream).
+  # Pin to a specific tag (e.g. v3.11.7-full) before each gcplane release.
+  GOCLAW_VERSION: "latest-full"
 
 jobs:
   e2e:
@@ -44,7 +47,7 @@ jobs:
             -e GOCLAW_GATEWAY_TOKEN=test-token-ci \
             -e GOCLAW_ENCRYPTION_KEY=$(openssl rand -hex 32) \
             -e GOCLAW_POSTGRES_DSN=postgres://goclaw:goclaw@localhost:5432/goclaw?sslmode=disable \
-            ghcr.io/nextlevelbuilder/goclaw:${{ env.GOCLAW_VERSION }}
+            ghcr.io/dataplanelabs/goclaw:${{ env.GOCLAW_VERSION }}
 
           for i in $(seq 1 30); do
             if curl -sf http://localhost:18790/health > /dev/null 2>&1; then

--- a/internal/manifest/field_config.go
+++ b/internal/manifest/field_config.go
@@ -45,3 +45,26 @@ var writeOnlyFields = map[ResourceKind][]string{
 func WriteOnlyFields(kind ResourceKind) []string {
 	return writeOnlyFields[kind]
 }
+
+// kindsSupportingWriteOnlyHash lists resource kinds whose goclaw side accepts
+// and echoes back a writeOnlyHash field on list/get. Only these kinds get the
+// "empty observedHash treated as drift" safety-net in engine.stepCompare —
+// for kinds NOT in this set, goclaw silently drops the field, so an empty
+// observed value would otherwise create an infinite update loop.
+//
+// Add a kind here only after confirming goclaw migration + handler support.
+// Current support:
+//   - KindCronJob:  migration 000059 (goclaw)
+//   - KindProvider: migration 000060 (goclaw)
+var kindsSupportingWriteOnlyHash = map[ResourceKind]bool{
+	KindCronJob:  true,
+	KindProvider: true,
+}
+
+// SupportsWriteOnlyHash returns true if goclaw is known to persist + echo
+// the writeOnlyHash field for this kind. The reconciler uses this to decide
+// whether an empty observed hash should be treated as drift (auto-heal) or
+// as the legacy blind-noop case (kind whose goclaw side never echoes hash).
+func SupportsWriteOnlyHash(kind ResourceKind) bool {
+	return kindsSupportingWriteOnlyHash[kind]
+}

--- a/internal/manifest/skill_loader.go
+++ b/internal/manifest/skill_loader.go
@@ -33,10 +33,17 @@ type skillFrontmatter struct {
 
 // skillOverlay is loaded from an optional frontmatter.yaml co-located with
 // SKILL.md. It carries fields gcplane needs at apply time but that don't fit
-// inside SKILL.md's frontmatter (e.g. tags, status).
+// inside SKILL.md's frontmatter (e.g. tags, status, per-agent grants).
 type skillOverlay struct {
-	Tags   []string `yaml:"tags,omitempty"`
-	Status string   `yaml:"status,omitempty"`
+	Tags   []string             `yaml:"tags,omitempty"`
+	Status string               `yaml:"status,omitempty"`
+	Grants *skillGrantsOverlay  `yaml:"grants,omitempty"`
+}
+
+// skillGrantsOverlay mirrors the MCPServer `grants.agents` shape so per-agent
+// skill enablement is authored the same way across the manifest.
+type skillGrantsOverlay struct {
+	Agents []string `yaml:"agents,omitempty"`
 }
 
 // skillOverridesDoc is the schema of <tenant>/skill-overrides.yaml.
@@ -155,6 +162,13 @@ func loadSkillDir(skillDir, slug, scope string) (Resource, error) {
 				tags[i] = t
 			}
 			spec["tags"] = tags
+		}
+		if overlay.Grants != nil && len(overlay.Grants.Agents) > 0 {
+			agents := make([]any, len(overlay.Grants.Agents))
+			for i, a := range overlay.Grants.Agents {
+				agents[i] = a
+			}
+			spec["grants"] = map[string]any{"agents": agents}
 		}
 	} else if !os.IsNotExist(err) {
 		return Resource{}, fmt.Errorf("read %s: %w", overlayPath, err)

--- a/internal/manifest/skill_loader_test.go
+++ b/internal/manifest/skill_loader_test.go
@@ -123,6 +123,29 @@ func TestLoadSkillResources_FrontmatterOverlay(t *testing.T) {
 	}
 }
 
+func TestLoadSkillResources_GrantsOverlay(t *testing.T) {
+	dir := t.TempDir()
+	writeSkill(t, dir, "with-grants", "---\nname: With Grants\n---\n")
+
+	overlay := []byte("grants:\n  agents:\n    - van-anh\n    - assistant\n")
+	if err := os.WriteFile(filepath.Join(dir, "skills", "with-grants", "frontmatter.yaml"), overlay, 0o644); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	res, err := LoadSkillResources(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	grants, ok := res[0].Spec["grants"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected grants map, got %v", res[0].Spec["grants"])
+	}
+	agents, _ := grants["agents"].([]any)
+	if len(agents) != 2 || agents[0] != "van-anh" || agents[1] != "assistant" {
+		t.Errorf("grants.agents overlay not applied: %v", agents)
+	}
+}
+
 func TestLoadDir_YamlAndFilesystemConflict(t *testing.T) {
 	root := t.TempDir()
 	// YAML resource

--- a/internal/provider/goclaw/skill_test.go
+++ b/internal/provider/goclaw/skill_test.go
@@ -68,6 +68,9 @@ func TestSkill_Update_FiltersToWritableFields(t *testing.T) {
 			json.NewDecoder(r.Body).Decode(&putBody)
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(putBody)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/agents":
+			// Empty tenant — applySkillGrants finds nothing to add/remove.
+			json.NewEncoder(w).Encode(map[string]any{"agents": []map[string]any{}})
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
@@ -228,6 +231,70 @@ func TestSkill_Create_UploadsZIP(t *testing.T) {
 	}
 	if !gotMultipart {
 		t.Error("server never saw a multipart upload")
+	}
+}
+
+// TestSkill_Update_ReconcilesGrants verifies update path: when spec declares
+// grants.agents=[van-anh], a currently-granted [old-bot] is revoked and
+// van-anh is granted.
+func TestSkill_Update_ReconcilesGrants(t *testing.T) {
+	var grantedAgentIDs []string
+	var revokedAgentIDs []string
+
+	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/skills":
+			json.NewEncoder(w).Encode(map[string]any{
+				"skills": []map[string]any{{"id": "skill-uuid", "slug": "sales-of-day"}},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/skills/skill-uuid":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/agents":
+			json.NewEncoder(w).Encode(map[string]any{
+				"agents": []map[string]any{
+					{"id": "agent-van-anh", "agent_key": "van-anh"},
+					{"id": "agent-old-bot", "agent_key": "old-bot"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/agents/agent-van-anh/skills":
+			// van-anh: not yet granted
+			json.NewEncoder(w).Encode(map[string]any{
+				"skills": []map[string]any{{"id": "skill-uuid", "slug": "sales-of-day", "granted": false}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/agents/agent-old-bot/skills":
+			// old-bot: currently granted, must be revoked
+			json.NewEncoder(w).Encode(map[string]any{
+				"skills": []map[string]any{{"id": "skill-uuid", "slug": "sales-of-day", "granted": true}},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/skills/skill-uuid/grants/agent":
+			var body map[string]any
+			json.NewDecoder(r.Body).Decode(&body)
+			grantedAgentIDs = append(grantedAgentIDs, body["agent_id"].(string))
+			w.WriteHeader(http.StatusCreated)
+		case r.Method == http.MethodDelete:
+			// /v1/skills/skill-uuid/grants/agent/{agentID}
+			parts := strings.Split(r.URL.Path, "/")
+			revokedAgentIDs = append(revokedAgentIDs, parts[len(parts)-1])
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer cleanup()
+
+	spec := map[string]any{
+		"description": "daily sales summary",
+		"grants":      map[string]any{"agents": []any{"van-anh"}},
+	}
+	if err := p.Update(context.Background(), manifest.KindSkill, "sales-of-day", spec); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	if len(grantedAgentIDs) != 1 || grantedAgentIDs[0] != "agent-van-anh" {
+		t.Errorf("expected grant for agent-van-anh, got %v", grantedAgentIDs)
+	}
+	if len(revokedAgentIDs) != 1 || revokedAgentIDs[0] != "agent-old-bot" {
+		t.Errorf("expected revoke for agent-old-bot, got %v", revokedAgentIDs)
 	}
 }
 

--- a/internal/provider/goclaw/skills.go
+++ b/internal/provider/goclaw/skills.go
@@ -31,6 +31,9 @@ var skillWritableFields = map[string]struct{}{
 // observeSkill fetches a skill by slug from GoClaw.
 // goclaw's list response keys skills by `slug`; the older code matched on
 // `key`, which never resolved against a real backend.
+//
+// Also folds per-agent grants into spec["grants"]["agents"] so the reconciler
+// can detect grant drift the same way it does for MCPServer.
 func (p *Provider) observeSkill(ctx context.Context, key string) (map[string]any, error) {
 	data, err := p.http.Get(ctx, "/v1/skills")
 	if err != nil {
@@ -46,7 +49,14 @@ func (p *Provider) observeSkill(ctx context.Context, key string) (map[string]any
 
 	for _, s := range resp.Skills {
 		if matchSkillKey(s, key) && p.matchesTenant(ctx, s) {
-			return translateResult(stripInternal(s)), nil
+			skillID := strVal(s, "id")
+			result := translateResult(stripInternal(s))
+			if skillID != "" {
+				if agentKeys, err := p.listSkillGrantAgentKeys(ctx, skillID); err == nil {
+					result["grants"] = map[string]any{"agents": agentKeys}
+				}
+			}
+			return result, nil
 		}
 	}
 	return nil, nil
@@ -102,8 +112,17 @@ func (p *Provider) createSkill(ctx context.Context, key string, spec map[string]
 	// writable subset. Skip the PUT when there are no overlay fields to
 	// avoid a wasted round-trip.
 	if hasOverlay(spec) {
-		if err := p.updateSkill(ctx, key, spec); err != nil {
+		if err := p.putSkillFields(ctx, key, spec); err != nil {
 			return fmt.Errorf("apply overlay to skill %s after upload: %w", key, err)
+		}
+	}
+	// Reconcile per-agent grants when the manifest declares any. Mirrors
+	// createMCPServer: on create we only add (no implicit revoke), since
+	// there can be no pre-existing state for a brand-new skill. The
+	// update path below handles declarative revokes.
+	if agents := extractGrantAgents(spec); len(agents) > 0 {
+		if err := p.applySkillGrants(ctx, key, agents); err != nil {
+			return fmt.Errorf("apply grants for skill %s: %w", key, err)
 		}
 	}
 	return nil
@@ -138,9 +157,18 @@ func (p *Provider) deleteSkill(ctx context.Context, key string) error {
 }
 
 // updateSkill updates an existing skill in GoClaw.
-// Sends only writable fields; observed-only fields (version, etc.) are
-// allowed through but goclaw will accept or ignore them.
+// Sends only writable fields, then reconciles per-agent grants.
 func (p *Provider) updateSkill(ctx context.Context, key string, spec map[string]any) error {
+	if err := p.putSkillFields(ctx, key, spec); err != nil {
+		return err
+	}
+	return p.applySkillGrants(ctx, key, extractGrantAgents(spec))
+}
+
+// putSkillFields PUTs the writable subset of spec to /v1/skills/{id}.
+// Observed-only fields (version, etc.) are allowed through but goclaw will
+// accept or ignore them. Returns an error if the skill does not exist.
+func (p *Provider) putSkillFields(ctx context.Context, key string, spec map[string]any) error {
 	current, err := p.observeSkill(ctx, key)
 	if err != nil {
 		return err
@@ -163,4 +191,147 @@ func (p *Provider) updateSkill(ctx context.Context, key string, spec map[string]
 	body := translateSpec(writable)
 	_, err = p.http.Put(ctx, "/v1/skills/"+id, body)
 	return err
+}
+
+// resolveSkillIDFromList returns the UUID of a skill by slug. Mirrors the
+// MCPServer helper so applySkillGrants stays symmetric with applyMCPGrants.
+func (p *Provider) resolveSkillIDFromList(ctx context.Context, slug string) (string, error) {
+	data, err := p.http.Get(ctx, "/v1/skills")
+	if err != nil {
+		return "", fmt.Errorf("list skills: %w", err)
+	}
+	var resp struct {
+		Skills []map[string]any `json:"skills"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return "", fmt.Errorf("parse skills response: %w", err)
+	}
+	for _, s := range resp.Skills {
+		if strVal(s, "slug") == slug && p.matchesTenant(ctx, s) {
+			if id := strVal(s, "id"); id != "" {
+				return id, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("skill %q not found", slug)
+}
+
+// applySkillGrants reconciles desired per-agent grants for a skill:
+// adds missing grants and removes extra ones. Symmetric with applyMCPGrants.
+//
+// Passing a nil/empty desiredAgents revokes all current grants — same
+// semantics as MCPServer so a manifest that drops a name actually unwires it.
+func (p *Provider) applySkillGrants(ctx context.Context, slug string, desiredAgents []string) error {
+	skillID, err := p.resolveSkillIDFromList(ctx, slug)
+	if err != nil {
+		return err
+	}
+
+	currentAgents, err := p.listSkillGrantAgentKeys(ctx, skillID)
+	if err != nil {
+		return fmt.Errorf("list current grants for skill %s: %w", slug, err)
+	}
+
+	currentIDs := make(map[string]string, len(currentAgents)) // agent_key → agent_id
+	for _, agentKey := range currentAgents {
+		agentID, err := p.resolveAgentID(ctx, agentKey)
+		if err != nil {
+			return fmt.Errorf("resolve current grant agent %q: %w", agentKey, err)
+		}
+		currentIDs[agentKey] = agentID
+	}
+
+	desiredIDs := make(map[string]string, len(desiredAgents))
+	for _, agentKey := range desiredAgents {
+		agentID, err := p.resolveAgentID(ctx, agentKey)
+		if err != nil {
+			return fmt.Errorf("resolve desired grant agent %q: %w", agentKey, err)
+		}
+		desiredIDs[agentKey] = agentID
+	}
+
+	// Add missing grants. version=0 lets goclaw default to 1 (handleGrantAgent).
+	for agentKey, agentID := range desiredIDs {
+		if _, exists := currentIDs[agentKey]; exists {
+			continue
+		}
+		body := map[string]any{"agent_id": agentID}
+		if _, err := p.http.Post(ctx, "/v1/skills/"+skillID+"/grants/agent", body); err != nil {
+			return fmt.Errorf("grant skill %s to agent %s: %w", slug, agentKey, err)
+		}
+	}
+
+	// Remove extra grants.
+	for agentKey, agentID := range currentIDs {
+		if _, wanted := desiredIDs[agentKey]; wanted {
+			continue
+		}
+		path := "/v1/skills/" + skillID + "/grants/agent/" + agentID
+		if err := p.http.Delete(ctx, path); err != nil && !errors.Is(err, ErrNotFound) {
+			return fmt.Errorf("revoke skill %s from agent %s: %w", slug, agentKey, err)
+		}
+	}
+	return nil
+}
+
+// listSkillGrantAgentKeys returns the agent_keys that currently have this
+// skill granted. goclaw exposes grants per agent (GET /v1/agents/{id}/skills)
+// but not per skill, so we fan out across the tenant's agents and filter for
+// granted == true. Small tenants only; not optimised for hundreds of agents.
+func (p *Provider) listSkillGrantAgentKeys(ctx context.Context, skillID string) ([]string, error) {
+	agentData, err := p.http.Get(ctx, "/v1/agents")
+	if err != nil {
+		return nil, fmt.Errorf("list agents for skill-grant resolution: %w", err)
+	}
+	var agentResp struct {
+		Agents []map[string]any `json:"agents"`
+	}
+	if err := json.Unmarshal(agentData, &agentResp); err != nil {
+		return nil, fmt.Errorf("parse agents response: %w", err)
+	}
+
+	keys := make([]string, 0)
+	for _, a := range agentResp.Agents {
+		if !p.matchesTenant(ctx, a) {
+			continue
+		}
+		agentID := strVal(a, "id")
+		agentKey := strVal(a, "agent_key")
+		if agentID == "" || agentKey == "" {
+			continue
+		}
+		granted, err := p.agentHasSkillGrant(ctx, agentID, skillID)
+		if err != nil {
+			return nil, err
+		}
+		if granted {
+			keys = append(keys, agentKey)
+		}
+	}
+	return keys, nil
+}
+
+// agentHasSkillGrant returns true when GET /v1/agents/{agentID}/skills
+// reports skillID with granted=true.
+func (p *Provider) agentHasSkillGrant(ctx context.Context, agentID, skillID string) (bool, error) {
+	data, err := p.http.Get(ctx, "/v1/agents/"+agentID+"/skills")
+	if err != nil {
+		return false, fmt.Errorf("list skills for agent %s: %w", agentID, err)
+	}
+	var resp struct {
+		Skills []map[string]any `json:"skills"`
+	}
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return false, fmt.Errorf("parse agent skills response: %w", err)
+	}
+	for _, s := range resp.Skills {
+		if strVal(s, "id") != skillID {
+			continue
+		}
+		if g, ok := s["granted"].(bool); ok && g {
+			return true, nil
+		}
+		return false, nil
+	}
+	return false, nil
 }

--- a/internal/reconciler/engine.go
+++ b/internal/reconciler/engine.go
@@ -327,14 +327,32 @@ func (e *Engine) stepCompare(_ context.Context, rc *reconcileContext) error {
 	// Check write-only hash drift using pre-computed hash.
 	// Hash was computed once above and is carried on Change for the execute phase,
 	// avoiding a second secret resolution that could produce a different value.
+	//
+	// Drift conditions:
+	//   1. Both hashes present and differ          → real rotation/change
+	//   2. Desired present, observed empty, kind   → first reconcile after the
+	//      supports writeOnlyHash on goclaw side     goclaw migration adding
+	//                                                writeOnlyHash echo (existing
+	//                                                rows have empty default).
+	//                                                One-shot update populates
+	//                                                observed; subsequent
+	//                                                reconciles converge.
+	//
+	// For kinds whose goclaw side does NOT echo writeOnlyHash, the empty
+	// observed value cannot mean "drift" — it means "no support." Treating it
+	// as drift would create an infinite update loop. Those kinds keep the
+	// strict both-non-empty check and fall through to warnBlindNoop instead.
 	desiredHash := rc.change.WriteOnlyHash
 	observedHash, _ := rc.current[WriteOnlyHashField].(string)
-	if desiredHash != "" && observedHash != "" && desiredHash != observedHash {
+	hashesDiffer := desiredHash != "" && desiredHash != observedHash
+	canAutoHeal := observedHash == "" && manifest.SupportsWriteOnlyHash(rc.resource.Kind)
+	if hashesDiffer && (observedHash != "" || canAutoHeal) {
 		e.logger.Info("write-only hash mismatch",
 			slog.String("kind", string(rc.resource.Kind)),
 			slog.String("name", rc.resource.Name),
 			slog.String("observed", observedHash),
-			slog.String("desired", desiredHash))
+			slog.String("desired", desiredHash),
+			slog.Bool("observed_empty", observedHash == ""))
 		diffs[WriteOnlyHashField] = FieldDiff{Old: observedHash, New: desiredHash}
 	}
 

--- a/internal/reconciler/engine_test.go
+++ b/internal/reconciler/engine_test.go
@@ -589,9 +589,13 @@ func TestWarnBlindNoop_NoWarnOnCreate(t *testing.T) {
 }
 
 func TestWarnBlindNoop_GenericAcrossKinds(t *testing.T) {
-	// Provider with apiKey (blind field) — noop should warn
+	// MCPServer with grants (blind field) — kind NOT in kindsSupportingWriteOnlyHash
+	// allowlist, so goclaw side does not echo the writeOnlyHash. Reconciler cannot
+	// auto-heal → falls through to noop + blind-noop WARN. This is the legacy
+	// behavior preserved for kinds whose goclaw side has not yet been migrated to
+	// support the writeOnlyHash echo (only CronJob + Provider as of this PR).
 	provider := newMockProvider()
-	provider.observed["Provider/anthropic"] = map[string]any{"displayName": "Anthropic"}
+	provider.observed["MCPServer/k8s"] = map[string]any{"transport": "stdio"}
 
 	var buf bytes.Buffer
 	engine := NewEngine(provider, newTestLogger(&buf))
@@ -599,11 +603,11 @@ func TestWarnBlindNoop_GenericAcrossKinds(t *testing.T) {
 	m := &manifest.Manifest{
 		Resources: []manifest.Resource{
 			{
-				Kind: manifest.KindProvider,
-				Name: "anthropic",
+				Kind: manifest.KindMCPServer,
+				Name: "k8s",
 				Spec: map[string]any{
-					"displayName": "Anthropic",
-					"apiKey":      "sk-secret-key",
+					"transport": "stdio",
+					"grants":    map[string]any{"alice": "ro"},
 				},
 			},
 		},
@@ -616,10 +620,10 @@ func TestWarnBlindNoop_GenericAcrossKinds(t *testing.T) {
 
 	out := buf.String()
 	if !strings.Contains(out, "no-op may hide drift") {
-		t.Errorf("expected blind-noop warning for Provider/apiKey, got:\n%s", out)
+		t.Errorf("expected blind-noop warning for MCPServer/grants, got:\n%s", out)
 	}
-	if !strings.Contains(out, "apiKey") {
-		t.Errorf("expected 'apiKey' in warning log, got:\n%s", out)
+	if !strings.Contains(out, "grants") {
+		t.Errorf("expected 'grants' in warning log, got:\n%s", out)
 	}
 }
 
@@ -661,9 +665,12 @@ func TestWarnBlindNoop_NoWarnOnHashConfirmedNoop(t *testing.T) {
 }
 
 func TestWarnBlindNoop_NoWarnWhenBlindFieldEmptyString(t *testing.T) {
-	// Provider with apiKey: "" — empty-string blind field → treat as trivial, no warn.
+	// MCPServer with empty/missing blind field "grants" → no value to apply,
+	// hash function skips missing-key entries, desiredHash="" → no drift to
+	// hide → no warn. Uses MCPServer (not in kindsSupportingWriteOnlyHash) so
+	// the empty-observed-hash path doesn't trigger an auto-heal update.
 	provider := newMockProvider()
-	provider.observed["Provider/anthropic"] = map[string]any{"displayName": "Anthropic"}
+	provider.observed["MCPServer/k8s"] = map[string]any{"transport": "stdio"}
 
 	var buf bytes.Buffer
 	engine := NewEngine(provider, newTestLogger(&buf))
@@ -671,11 +678,13 @@ func TestWarnBlindNoop_NoWarnWhenBlindFieldEmptyString(t *testing.T) {
 	m := &manifest.Manifest{
 		Resources: []manifest.Resource{
 			{
-				Kind: manifest.KindProvider,
-				Name: "anthropic",
+				Kind: manifest.KindMCPServer,
+				Name: "k8s",
 				Spec: map[string]any{
-					"displayName": "Anthropic",
-					"apiKey":      "",
+					"transport": "stdio",
+					// "grants" intentionally absent — manifest declares no
+					// access grants; hash builder ignores missing keys, so
+					// desiredHash is empty and warnBlindNoop is silent.
 				},
 			},
 		},
@@ -688,7 +697,7 @@ func TestWarnBlindNoop_NoWarnWhenBlindFieldEmptyString(t *testing.T) {
 
 	out := buf.String()
 	if strings.Contains(out, "no-op may hide drift") {
-		t.Errorf("unexpected blind-noop warning for empty-string apiKey:\n%s", out)
+		t.Errorf("unexpected blind-noop warning for absent blind field:\n%s", out)
 	}
 }
 
@@ -810,5 +819,110 @@ func TestReconcile_BuiltinToolConfig_BackwardCompat_NoSettings(t *testing.T) {
 	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
 	if plan.Noops != 1 {
 		t.Errorf("expected noop for enabled-only BuiltinToolConfig, got noops=%d updates=%d", plan.Noops, plan.Updates)
+	}
+}
+
+// TestReconcile_EmptyObservedHash_AutoHealsSupportedKind verifies the
+// safety-net: when goclaw has the resource but never echoed a writeOnlyHash
+// (existing row before migration 000060 / 000059 ran), the reconciler
+// triggers a one-shot update to populate it. This fixes the production
+// "zai-coding 401" incident where rotated apiKeys never propagated because
+// the reconciler saw no drift on the masked api_key field.
+func TestReconcile_EmptyObservedHash_AutoHealsSupportedKind(t *testing.T) {
+	provider := newMockProvider()
+	// Provider exists in goclaw but writeOnlyHash is empty (legacy row).
+	provider.observed["Provider/zai-coding"] = map[string]any{
+		"displayName": "Z.ai Coding",
+		// no writeOnlyHash field
+	}
+
+	engine := NewEngine(provider, nil)
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindProvider,
+				Name: "zai-coding",
+				Spec: map[string]any{
+					"displayName": "Z.ai Coding",
+					"apiKey":      "sk-rotated-key",
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Updates != 1 {
+		t.Fatalf("expected 1 update (auto-heal for KindProvider), got updates=%d noops=%d", plan.Updates, plan.Noops)
+	}
+	for _, ch := range plan.Changes {
+		if ch.Action == ActionUpdate {
+			if _, ok := ch.Diff["writeOnlyHash"]; !ok {
+				t.Error("expected writeOnlyHash in auto-heal diff")
+			}
+		}
+	}
+}
+
+// TestReconcile_EmptyObservedHash_NoLoopForUnsupportedKind guards against the
+// failure mode the allowlist exists to prevent: for kinds whose goclaw side
+// does NOT echo writeOnlyHash (every kind except CronJob + Provider as of
+// migration 000060), treating empty observedHash as drift would cause an
+// infinite update loop. The allowlist ensures unsupported kinds stay on the
+// strict both-non-empty check, falling through to blind-noop WARN instead.
+func TestReconcile_EmptyObservedHash_NoLoopForUnsupportedKind(t *testing.T) {
+	provider := newMockProvider()
+	// MCPServer is not in kindsSupportingWriteOnlyHash. goclaw doesn't echo
+	// the hash for this kind, so the observed map never includes it.
+	provider.observed["MCPServer/k8s"] = map[string]any{"transport": "stdio"}
+
+	engine := NewEngine(provider, nil)
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindMCPServer,
+				Name: "k8s",
+				Spec: map[string]any{
+					"transport": "stdio",
+					"grants":    map[string]any{"alice": "ro"},
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected noop (unsupported kind must not auto-heal), got noops=%d updates=%d", plan.Noops, plan.Updates)
+	}
+}
+
+// TestReconcile_HashMatchesAfterAutoHeal verifies that once the first auto-heal
+// update populates the observed hash, the next reconcile converges to noop —
+// proving the safety-net is one-shot, not a perpetual update.
+func TestReconcile_HashMatchesAfterAutoHeal(t *testing.T) {
+	spec := map[string]any{
+		"displayName": "Z.ai Coding",
+		"apiKey":      "sk-stable-key",
+	}
+	woFields := manifest.WriteOnlyFields(manifest.KindProvider)
+	expectedHash := HashWriteOnlyFields(spec, woFields, nil)
+
+	provider := newMockProvider()
+	// Simulate the state AFTER the first auto-heal update applied: goclaw now
+	// echoes the writeOnlyHash matching the manifest.
+	provider.observed["Provider/zai-coding"] = map[string]any{
+		"displayName":   "Z.ai Coding",
+		"writeOnlyHash": expectedHash,
+	}
+
+	engine := NewEngine(provider, nil)
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{Kind: manifest.KindProvider, Name: "zai-coding", Spec: spec},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 {
+		t.Fatalf("expected noop on hash match (post-heal steady state), got noops=%d updates=%d", plan.Noops, plan.Updates)
 	}
 }


### PR DESCRIPTION
Pairs with [dataplanelabs/goclaw#5](https://github.com/dataplanelabs/goclaw/pull/5). Together they fix the production zai-coding 401 incident.

## Why

After dataplanelabs/goclaw#5 ships migration 000060, existing llm_providers rows have write_only_hash=''. Without this change, the reconciler's strict 'both hashes non-empty' check would still skip drift detection → rows would NEVER converge to the new contract unless someone created them fresh. So we'd ship support but never actually use it.

This adds a one-shot safety-net: when desiredHash is computed but observedHash is empty AND the kind is in the new kindsSupportingWriteOnlyHash allowlist, treat as drift. The first reconcile post-deploy pushes the hash → goclaw stores it → next reconcile sees matching hashes → steady-state noop. One auto-heal update per existing row.

## Loop prevention

The allowlist gate is essential. For kinds whose goclaw side does NOT echo writeOnlyHash (Channel, Agent, MCPServer, AgentTeam, Skill, MCPCredentials, SecureCLI, SecureCLIGrant, AgentLink), every reconcile would send an update, goclaw would silently drop the field, observed would stay empty, next reconcile would loop forever.

Only KindCronJob (goclaw migration 000059) and KindProvider (goclaw migration 000060) are in the allowlist today. Add a new kind only after goclaw ships matching support. For non-allowlisted kinds, behavior is unchanged — strict both-non-empty check falls through to noop + the existing blind-noop WARN.

## Test plan

- [x] go test -count=1 ./internal/reconciler/ ./internal/manifest/ — all green
- [x] 3 new tests: AutoHealsSupportedKind, NoLoopForUnsupportedKind, HashMatchesAfterAutoHeal
- [x] 2 existing blind-noop tests reworked from Provider (now auto-heals) to MCPServer (still legacy blind-noop) — preserves the original WARN regression guard
- [ ] Production verify after deploy: each Provider in each tenant gets exactly one 'write-only hash mismatch' + update on first reconcile, then steady state. zai-coding 'no-op may hide drift' warning disappears.

## Pairs with

dataplanelabs/goclaw#5

Refs: https://github.com/dataplanelabs/gcplane/issues/9