### PR TITLE
feat(provider/goclaw,manifest): stamp source=gcplane + pre-flight validate

### DIFF
--- a/internal/manifest/validate.go
+++ b/internal/manifest/validate.go
@@ -3,6 +3,8 @@ package manifest
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/dataplanelabs/gcplane/internal/skillpkg"
 )
 
 var keyRe = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
@@ -119,6 +121,11 @@ func validateSkillSpec(prefix string, spec map[string]any) []error {
 				}
 				seen[s] = true
 			}
+		}
+	}
+	if src, ok := spec["sourceDir"].(string); ok && src != "" {
+		if _, err := skillpkg.PackDir(src); err != nil {
+			errs = append(errs, fmt.Errorf("%s: spec.sourceDir %q: %w", prefix, src, err))
 		}
 	}
 	return errs

--- a/internal/manifest/validate_test.go
+++ b/internal/manifest/validate_test.go
@@ -1,6 +1,8 @@
 package manifest
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -65,6 +67,123 @@ func TestValidate_DuplicateResource(t *testing.T) {
 	errs := Validate(m)
 	if len(errs) == 0 {
 		t.Error("expected error for duplicate resource")
+	}
+}
+
+func TestValidateSkillSpec_SourceDirMissing(t *testing.T) {
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindSkill, Name: "gh-read", Spec: map[string]any{
+				"sourceDir": "/nonexistent/path/skills/gh-read",
+			}},
+		},
+	}
+	errs := Validate(m)
+	if len(errs) == 0 {
+		t.Fatal("expected error for missing sourceDir")
+	}
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "sourceDir") && strings.Contains(err.Error(), "/nonexistent/path") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected sourceDir error citing path, got: %v", errs)
+	}
+}
+
+func TestValidateSkillSpec_SourceDirNoSkillMd(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindSkill, Name: "no-md", Spec: map[string]any{"sourceDir": dir}},
+		},
+	}
+	errs := Validate(m)
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "SKILL.md") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SKILL.md error, got: %v", errs)
+	}
+}
+
+func TestValidateSkillSpec_OversizeFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	big := make([]byte, (4*1024*1024)+1)
+	if err := os.WriteFile(filepath.Join(dir, "big.bin"), big, 0o644); err != nil {
+		t.Fatalf("write big.bin: %v", err)
+	}
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindSkill, Name: "oversize", Spec: map[string]any{"sourceDir": dir}},
+		},
+	}
+	errs := Validate(m)
+	found := false
+	for _, err := range errs {
+		if strings.Contains(err.Error(), "big.bin") && strings.Contains(err.Error(), "exceeds") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected oversize error for big.bin, got: %v", errs)
+	}
+}
+
+func TestValidateSkillSpec_SkipsHiddenAndGitFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, ".git", "objects", "pack"), 0o755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
+	bigPack := make([]byte, (4*1024*1024)+1)
+	if err := os.WriteFile(filepath.Join(dir, ".git", "objects", "pack", "pack.bin"), bigPack, 0o644); err != nil {
+		t.Fatalf("write pack: %v", err)
+	}
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindSkill, Name: "with-git", Spec: map[string]any{"sourceDir": dir}},
+		},
+	}
+	errs := Validate(m)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors (validate must skip .git like skillpkg does), got: %v", errs)
+	}
+}
+
+func TestValidateSkillSpec_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: x\n---\nbody\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+	m := &Manifest{
+		APIVersion: "gcplane.io/v1",
+		Kind:       "Manifest",
+		Resources: []Resource{
+			{Kind: KindSkill, Name: "happy", Spec: map[string]any{"sourceDir": dir}},
+		},
+	}
+	errs := Validate(m)
+	if len(errs) != 0 {
+		t.Errorf("expected zero errors on happy path, got: %v", errs)
 	}
 }
 

--- a/internal/provider/goclaw/skill_test.go
+++ b/internal/provider/goclaw/skill_test.go
@@ -215,6 +215,9 @@ func TestSkill_Create_UploadsZIP(t *testing.T) {
 			} else {
 				gotMultipart = true
 			}
+			if got := r.FormValue("source"); got != "gcplane" {
+				t.Errorf("expected source=gcplane form field, got %q", got)
+			}
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{"slug": "test-skill", "version": 1})
 			return

--- a/internal/provider/goclaw/skills.go
+++ b/internal/provider/goclaw/skills.go
@@ -96,6 +96,10 @@ func (p *Provider) createSkill(ctx context.Context, key string, spec map[string]
 	if _, err := fw.Write(pkg.ZIP); err != nil {
 		return fmt.Errorf("multipart write: %w", err)
 	}
+	// source=gcplane lets goclaw refuse non-gcplane overwrites unless force_imperative.
+	if err := mw.WriteField("source", "gcplane"); err != nil {
+		return fmt.Errorf("multipart write source: %w", err)
+	}
 	if err := mw.Close(); err != nil {
 		return fmt.Errorf("multipart close: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `provider/goclaw/skills.go::createSkill` adds `mw.WriteField("source", "gcplane")` so goclaw can stamp uploaded skills as declaratively managed.
- `manifest/validate.go::validateSkillSpec` delegates sourceDir checks to `skillpkg.PackDir` — single source of truth for both pre-flight and actual pack behavior (no more divergent skip rules).
- Client side of B1 skill install pipeline — pairs with goclaw PR #80 (server-side `source` column + 409 gate).

## Why

After goclaw PR #80, the server can refuse non-gcplane overwrites of `source=gcplane` skills (409 `managed_skill_overwrite`). gcplane must stamp `source=gcplane` so its own uploads stay marked correctly across re-applies; otherwise they'd land as `source=unknown` and the gate would be a no-op.

The `validateSkillSpec` refactor (HIGH finding from local code-review) collapses what was originally a custom `filepath.WalkDir` with bespoke skip rules into a single `skillpkg.PackDir(src)` call. Eliminates a real false-positive bug: a skill dir containing a large pack file under a hidden VCS directory would have failed validate but succeeded on actual upload (because skillpkg already skips hidden dirs by name). Now both paths share one implementation.

## Changes

### `internal/provider/goclaw/skills.go`
- `createSkill` multipart now writes `source=gcplane` form field before `mw.Close()`. 1-line comment explains why.

### `internal/manifest/validate.go`
- Drop self-rolled `os`/`path/filepath`/`io/fs`/`maxSkillFileSize` block.
- `if src, ok := spec["sourceDir"].(string); ok && src != "" { skillpkg.PackDir(src) → wrap err }` — that's it.
- New import: `internal/skillpkg`.

### Tests
- `internal/provider/goclaw/skill_test.go::TestSkill_Create_UploadsZIP` — added assertion: server-side `r.FormValue("source")` must equal `"gcplane"`.
- 5 new validate tests in `internal/manifest/validate_test.go`:
  - `TestValidateSkillSpec_SourceDirMissing` — non-existent path → error citing path
  - `TestValidateSkillSpec_SourceDirNoSkillMd` — empty dir → error citing `SKILL.md`
  - `TestValidateSkillSpec_OversizeFile` — 4 MiB+1 file → error citing `big.bin` + `exceeds`
  - `TestValidateSkillSpec_SkipsHiddenAndGitFiles` — regression guard: large pack file under hidden VCS dir must NOT trigger error (matches skillpkg skip)
  - `TestValidateSkillSpec_HappyPath` — `len(errs) == 0` on valid dir

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — 15/15 packages pass

## Companion changes (separate PRs)

- **goclaw** [dataplanelabs/goclaw#80](https://github.com/dataplanelabs/goclaw/pull/80) — server-side `source` column + 409 gate
- **goclaw-config** `feat/system-skill-gh-read` — pilot `_system/skills/gh-read/`

## Decisions captured (post-review)

- HIGH (resolved): `filepath.WalkDir` with no skip rules → false-positive reject on large pack files under hidden VCS dirs. Fixed by delegating to `skillpkg.PackDir`.
- MEDIUM (resolved alongside): `maxSkillFileSize` literal duplicated `skillpkg.MaxFileSize` → removed entirely; skillpkg owns the cap.
- LOW (resolved): `TestValidateSkillSpec_HappyPath` tightened from "no errors mentioning sourceDir" to `len(errs) == 0`.
