### PR TITLE
feat(reconciler): enable writeOnlyHash drift detection for Agent

### DIFF
--- a/internal/manifest/field_config.go
+++ b/internal/manifest/field_config.go
@@ -56,9 +56,12 @@ func WriteOnlyFields(kind ResourceKind) []string {
 // Current support:
 //   - KindCronJob:  migration 000059 (goclaw)
 //   - KindProvider: migration 000060 (goclaw)
+//   - KindAgent:    migration 000076 (goclaw) — covers contextFiles + all
+//     write-only JSONB configs (toolsConfig, sandboxConfig, ...)
 var kindsSupportingWriteOnlyHash = map[ResourceKind]bool{
 	KindCronJob:  true,
 	KindProvider: true,
+	KindAgent:    true,
 }
 
 // SupportsWriteOnlyHash returns true if goclaw is known to persist + echo

--- a/internal/provider/goclaw/skills.go
+++ b/internal/provider/goclaw/skills.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log/slog"
 	"mime/multipart"
+	"path/filepath"
+	"strings"
 
 	"github.com/dataplanelabs/gcplane/internal/manifest"
 	"github.com/dataplanelabs/gcplane/internal/skillpkg"
@@ -116,6 +118,15 @@ func (p *Provider) createSkill(ctx context.Context, key string, spec map[string]
 	// source=gcplane lets goclaw refuse non-gcplane overwrites unless force_imperative.
 	if err := mw.WriteField("source", "gcplane"); err != nil {
 		return fmt.Errorf("multipart write source: %w", err)
+	}
+	// is_system=true for skills under _system/ — closes the B1 manual DB
+	// backfill (issue dataplanelabs/gcplane#14). Detection: sourceDir path
+	// contains a /_system/ segment OR starts with _system/. Other tenants'
+	// skills land with is_system=false (the goclaw upload default).
+	if isSystemSourceDir(sourceDir) {
+		if err := mw.WriteField("is_system", "true"); err != nil {
+			return fmt.Errorf("multipart write is_system: %w", err)
+		}
 	}
 	if err := mw.Close(); err != nil {
 		return fmt.Errorf("multipart close: %w", err)
@@ -355,4 +366,16 @@ func (p *Provider) agentHasSkillGrant(ctx context.Context, agentID, skillID stri
 		return false, nil
 	}
 	return false, nil
+}
+
+// isSystemSourceDir reports whether the given filesystem path is under a
+// `_system/` directory anywhere in its ancestry. Used by createSkill to mark
+// uploads with is_system=true so goclaw exposes them cross-tenant without a
+// manual DB UPDATE. See dataplanelabs/gcplane#14.
+func isSystemSourceDir(sourceDir string) bool {
+	clean := filepath.ToSlash(filepath.Clean(sourceDir))
+	if clean == "_system" || strings.HasPrefix(clean, "_system/") {
+		return true
+	}
+	return strings.Contains(clean, "/_system/")
 }

--- a/internal/provider/goclaw/skills_is_system_test.go
+++ b/internal/provider/goclaw/skills_is_system_test.go
@@ -1,0 +1,25 @@
+package goclaw
+
+import "testing"
+
+func TestIsSystemSourceDir(t *testing.T) {
+	cases := map[string]bool{
+		"_system":                                 true,
+		"_system/skills/gh-read":                  true,
+		"_system/skills/gws-calendar-read":        true,
+		"./_system/skills/foo":                    true,
+		"/abs/path/_system/skills/bar":            true,
+		"goclaw-config/_system/skills/baz":        true,
+
+		"annhien/skills/sales-of-day":             false,
+		"tenant/skills/_system_lookalike":         false,
+		"./skills/_system-fake/x":                 false,
+		"":                                        false,
+		"skills/something":                        false,
+	}
+	for in, want := range cases {
+		if got := isSystemSourceDir(in); got != want {
+			t.Errorf("isSystemSourceDir(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/internal/reconciler/engine_test.go
+++ b/internal/reconciler/engine_test.go
@@ -284,9 +284,12 @@ func TestReconcile_WriteOnlyHashDriftDetected(t *testing.T) {
 	}
 }
 
-func TestReconcile_WriteOnlyHashMissingIsNoop(t *testing.T) {
-	// Resource exists but GoClaw doesn't store/return writeOnlyHash.
-	// Without an observed hash, comparison is skipped to avoid permanent update drift.
+func TestReconcile_WriteOnlyHashMissingAutoHealsForSupportedKind(t *testing.T) {
+	// Resource exists but observed writeOnlyHash is empty. For kinds whose
+	// goclaw side echoes writeOnlyHash (CronJob, Provider, Agent), this is
+	// the first-reconcile-post-migration case: existing rows have empty
+	// default. The reconciler must treat empty observed as drift so the
+	// one-shot update populates observed; subsequent reconciles converge.
 	provider := newMockProvider()
 	provider.observed["Agent/bot"] = map[string]any{"model": "gpt-4"} // no writeOnlyHash
 
@@ -305,8 +308,8 @@ func TestReconcile_WriteOnlyHashMissingIsNoop(t *testing.T) {
 	}
 
 	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
-	if plan.Noops != 1 {
-		t.Errorf("expected noop (no observed hash to compare), got noops=%d updates=%d", plan.Noops, plan.Updates)
+	if plan.Updates != 1 {
+		t.Errorf("expected 1 auto-heal update (empty observed hash on supported kind), got updates=%d noops=%d", plan.Updates, plan.Noops)
 	}
 }
 


### PR DESCRIPTION
## Summary
Flip \`KindAgent: true\` in \`kindsSupportingWriteOnlyHash\` now that goclaw echoes \`writeOnlyHash\` on \`/v1/agents\`.

## Background
gcplane treats Agent.contextFiles / toolsConfig / sandboxConfig / subagentsConfig / memoryConfig / compactionConfig / contextPruning / otherConfig / reasoningConfig / workspaceSharing / chatgptOauthRouting / shellDenyGroups / kgDedupConfig / systemPrompt as **write-only** because the goclaw list API doesn't return them.

Without an opaque hash to compare, gcplane diffs only observable fields, sees no drift, logs the warning:
\`\`\`
resource no-op may hide drift in unobservable fields
kind=Agent unobservable_fields=[contextFiles toolsConfig]
\`\`\`
…and silently skips pushing IDENTITY.md / SOUL.md / toolsConfig edits to the goclaw runtime DB.

Hit this in production: shtp/agents.yaml edits to Mai Hà Lan / Thu Hà never reached the goclaw DB; had to bypass gcplane and patch \`agent_context_files\` directly via psql.

## Depends on
- **dataplanelabs/goclaw#135** — adds \`write_only_hash\` column + plumbing. Must merge + deploy first.

## Changes
- \`internal/manifest/field_config.go\` — add \`KindAgent: true\` to \`kindsSupportingWriteOnlyHash\` with comment pointing at goclaw migration 000076.
- \`internal/reconciler/engine_test.go\` — rename \`TestReconcile_WriteOnlyHashMissingIsNoop\` → \`MissingAutoHealsForSupportedKind\`, expect \`updates=1\`. The old name described the legacy blind-noop contract for kinds NOT in the supports list; with KindAgent flipped on, empty observed hash means "first reconcile post-migration" and triggers auto-heal exactly as designed for cron + provider.

## Behavior post-merge
1. Deploy gcplane.
2. First reconcile per tenant: each existing agent flagged \`write-only hash mismatch\` (observed empty) → one update each to populate the hash → existing IDENTITY.md / toolsConfig pushed.
3. Subsequent reconciles: noop while content matches; real edits detected as drift and pushed.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — zero failures
- [x] New test asserts auto-heal behavior
- [ ] Smoke after goclaw deploys: edit a tenant agent's IDENTITY.md in goclaw-config, observe gcplane logs \`write-only hash mismatch\` → \`drift detected\` → \`updating resource\`, verify DB row updates without manual psql bypass