### PR TITLE
fix(ws,controller): self-heal dead WS + recover Synced after transient errors

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -37,6 +37,7 @@ type Controller struct {
 	triggerCh      chan struct{}
 	logger         *slog.Logger
 	lastHash       string
+	lastHasErrors  bool // true when the previous reconcile produced errors; gates the unchanged-manifest skip so transient failures self-heal
 	debounceWindow time.Duration
 	debounceTimer  *time.Timer
 	mu             sync.Mutex
@@ -171,8 +172,13 @@ func (c *Controller) reconcileOnce() {
 		return
 	}
 
-	// Skip if manifest unchanged
-	if hash == c.lastHash && hash != "" {
+	// Skip if manifest unchanged AND prior reconcile succeeded. If the previous
+	// reconcile had errors (e.g. transient WS broken pipe, observe failure), a
+	// hash-equality skip would latch Synced=False forever — /readyz never
+	// recovers until a manifest change forces another full reconcile. Retrying
+	// the engine when prior errors exist self-heals within one cycle and is
+	// bounded (one extra reconcile per error).
+	if hash == c.lastHash && hash != "" && !c.lastHasErrors {
 		display := hash
 		if len(display) > 12 {
 			display = display[:12]
@@ -181,6 +187,9 @@ func (c *Controller) reconcileOnce() {
 		// Notify waiters with a no-op result so TriggerAndWait doesn't block forever.
 		c.notifyWaiters(&SyncResult{})
 		return
+	}
+	if hash == c.lastHash && hash != "" && c.lastHasErrors {
+		c.logger.Info("manifest unchanged but prior reconcile errored — retrying to self-heal")
 	}
 
 	engine := reconciler.NewEngine(c.provider, c.logger)
@@ -198,6 +207,7 @@ func (c *Controller) reconcileOnce() {
 
 	hasErrors := result.Failed > 0 || len(plan.Errors) > 0
 	hasDrift := plan.Creates > 0 || plan.Updates > 0
+	c.lastHasErrors = hasErrors
 
 	if hasErrors {
 		c.tracker.SetCondition(Condition{Type: ConditionSynced, Status: "False"})

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -470,3 +470,53 @@ func TestMetrics_Snapshot_ThreadSafe(t *testing.T) {
 	}
 	close(done)
 }
+
+// TestReconcileOnce_HashSkip_RetriesAfterPriorError verifies the self-heal
+// behavior: when a reconcile completes with errors, the next "manifest
+// unchanged" tick must NOT short-circuit — otherwise Synced=False latches
+// forever (readyz returns 503 until manifest changes). Regression for the
+// production bug where a transient observe broken-pipe left the pod
+// permanently NotReady.
+func TestReconcileOnce_HashSkip_RetriesAfterPriorError(t *testing.T) {
+	src := &mockSource{
+		manifest: &manifest.Manifest{
+			APIVersion: "gcplane.io/v1",
+			Kind:       "Manifest",
+			Metadata:   manifest.Metadata{Name: "test"},
+			Connection: manifest.Connection{Endpoint: "http://localhost:9999", Token: "tok"},
+			Resources: []manifest.Resource{
+				{Kind: manifest.KindAgent, Name: "bot", Spec: map[string]any{"model": "gpt-4"}},
+			},
+		},
+		hash: testHash,
+	}
+	// First reconcile: observe returns an error → plan.Errors populated → hasErrors=true.
+	prov := &mockProvider{observeErr: errors.New("ws write: broken pipe")}
+	ctrl := newTestController(src, prov)
+
+	ctrl.reconcileOnce()
+	if !ctrl.lastHasErrors {
+		t.Fatal("expected lastHasErrors=true after observe failure")
+	}
+
+	// Second reconcile with same hash: would normally skip, but lastHasErrors
+	// must force a retry. Heal the underlying error so the retry succeeds.
+	prov.observeErr = nil
+	prov.observeResult = nil // → ActionCreate path; createErr=nil → applied
+	beforeCalls := src.calls.Load()
+	ctrl.reconcileOnce()
+	if src.calls.Load() != beforeCalls+1 {
+		t.Errorf("expected Fetch called once more (retry), got delta %d", src.calls.Load()-beforeCalls)
+	}
+	if ctrl.lastHasErrors {
+		t.Error("expected lastHasErrors=false after successful retry")
+	}
+
+	// Third reconcile with same hash and no prior error: should now skip normally.
+	beforeSuccess := ctrl.metrics.Snapshot().SyncSuccess
+	ctrl.reconcileOnce()
+	if ctrl.metrics.Snapshot().SyncSuccess != beforeSuccess {
+		t.Errorf("expected third call to skip (no metrics delta), got SyncSuccess delta %d",
+			ctrl.metrics.Snapshot().SyncSuccess-beforeSuccess)
+	}
+}

--- a/internal/provider/goclaw/provider.go
+++ b/internal/provider/goclaw/provider.go
@@ -50,8 +50,7 @@ type Provider struct {
 	logger     *slog.Logger
 	http       *HTTPClient
 	ws         *WSClient
-	wsMu       sync.Mutex
-	wsReady    bool
+	wsMu       sync.Mutex // serializes Connect attempts; per-call WS state lives on WSClient
 	tenantOnce sync.Once
 	tenantErr  error
 }
@@ -78,21 +77,24 @@ func New(endpoint, token string, opts ...Option) *Provider {
 	return p
 }
 
-// ensureWS lazily connects the WebSocket client, retrying on transient failures.
-// Unlike sync.Once, a failed connection does not permanently disable WS operations.
+// ensureWS connects the WebSocket client if not already connected, and
+// reconnects after a dropped connection. WSClient.IsConnected() reflects
+// real socket state (cleared by readLoop on exit and by Call() on write
+// failure), so this self-heals after broken pipe / connection reset without
+// requiring a pod restart.
 func (p *Provider) ensureWS(ctx context.Context) error {
-	p.wsMu.Lock()
-	defer p.wsMu.Unlock()
-
-	if p.wsReady {
+	if p.ws.IsConnected() {
 		return nil
 	}
 
-	if err := p.ws.Connect(ctx); err != nil {
-		return err
+	p.wsMu.Lock()
+	defer p.wsMu.Unlock()
+
+	// Double-check under lock: another goroutine may have reconnected.
+	if p.ws.IsConnected() {
+		return nil
 	}
-	p.wsReady = true
-	return nil
+	return p.ws.Connect(ctx)
 }
 
 // SetEventHandler registers a callback for WS push events on the underlying WSClient.
@@ -128,10 +130,6 @@ func (p *Provider) StopLogTail(ctx context.Context) error {
 
 // Close releases provider resources (WS connection).
 func (p *Provider) Close() error {
-	p.wsMu.Lock()
-	p.wsReady = false
-	p.wsMu.Unlock()
-
 	if p.ws != nil {
 		return p.ws.Close()
 	}

--- a/internal/provider/goclaw/ws_client.go
+++ b/internal/provider/goclaw/ws_client.go
@@ -76,11 +76,25 @@ func (c *WSClient) SetEventHandler(h WSEventHandler) {
 	c.onEvent = h
 }
 
+// IsConnected reports whether the underlying socket is alive. Returns false
+// when never connected, when readLoop has exited (e.g., server-side close),
+// or when a write failure cleared the conn in Call().
+func (c *WSClient) IsConnected() bool {
+	c.connMu.Lock()
+	defer c.connMu.Unlock()
+	return c.conn != nil
+}
+
 // Connect dials the WebSocket endpoint and performs the v3 connect handshake.
-// After a successful handshake, starts the background readLoop goroutine.
+// Idempotent: returns nil immediately if already connected. After a successful
+// handshake, starts the background readLoop goroutine.
 func (c *WSClient) Connect(ctx context.Context) error {
 	c.connMu.Lock()
 	defer c.connMu.Unlock()
+
+	if c.conn != nil {
+		return nil
+	}
 
 	wsURL := "ws://" + c.endpoint + "/ws"
 	if parsed, err := url.Parse(c.endpoint); err == nil && parsed.Scheme != "" {
@@ -147,6 +161,7 @@ func (c *WSClient) Connect(ctx context.Context) error {
 // Takes conn directly to avoid racing with Close() which nils c.conn.
 func (c *WSClient) readLoop(conn *websocket.Conn) {
 	defer close(c.done)
+	defer c.clearConnIfSame(conn) // mark WS dead so ensureWS reconnects on next call
 	for {
 		_, msg, err := conn.ReadMessage()
 		if err != nil {
@@ -193,6 +208,17 @@ func (c *WSClient) deliverResponse(resp responseFrame) {
 	if ok {
 		ch <- resp
 	}
+}
+
+// clearConnIfSame nils c.conn iff it still points at the supplied conn.
+// Guards against racing with a concurrent reconnect that may have already
+// replaced c.conn with a new socket.
+func (c *WSClient) clearConnIfSame(conn *websocket.Conn) {
+	c.connMu.Lock()
+	if c.conn == conn {
+		c.conn = nil
+	}
+	c.connMu.Unlock()
 }
 
 // cancelAllPending fails all pending Call() waiters with the given error.
@@ -248,6 +274,10 @@ func (c *WSClient) Call(ctx context.Context, method string, params any) (json.Ra
 		c.pendingMu.Lock()
 		delete(c.pending, id)
 		c.pendingMu.Unlock()
+		// Write failure on a WS conn (broken pipe, connection reset) means the
+		// socket is dead — clear it so the next ensureWS reconnects. Without
+		// this, every subsequent Call hits the same dead conn until pod restart.
+		c.clearConnIfSame(conn)
 		return nil, fmt.Errorf("ws write %s: %w", method, err)
 	}
 

--- a/internal/provider/goclaw/ws_client_test.go
+++ b/internal/provider/goclaw/ws_client_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 )
@@ -240,3 +241,124 @@ func TestWSClient_Close_Connected(t *testing.T) {
 	// Close should not error
 	c.Close()
 }
+
+// TestWSClient_IsConnected_FalseAfterServerClose verifies that when the
+// server tears down the WS, readLoop's deferred clearConnIfSame fires and
+// IsConnected() flips to false. Regression for the bug where Provider
+// cached wsReady=true and never reconnected after a transient drop.
+func TestWSClient_IsConnected_FalseAfterServerClose(t *testing.T) {
+	connReady := make(chan struct{})
+	srv := newRawWSServer(t, func(conn *websocket.Conn) {
+		var req requestFrame
+		conn.ReadJSON(&req)
+		conn.WriteJSON(responseFrame{Type: "res", ID: req.ID, OK: true})
+		close(connReady)
+		// Server hangs up immediately.
+	})
+	defer srv.Close()
+
+	c := NewWSClient(srv.URL, "tok", "", "")
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if !c.IsConnected() {
+		t.Fatal("expected IsConnected=true right after Connect")
+	}
+	<-connReady
+	// Wait for readLoop to observe the close and clear the conn.
+	select {
+	case <-c.done:
+	case <-makeTimeout(2 * time.Second):
+		t.Fatal("readLoop did not exit within 2s after server close")
+	}
+	if c.IsConnected() {
+		t.Error("expected IsConnected=false after server-side close")
+	}
+}
+
+// TestWSClient_Connect_Idempotent verifies a second Connect() call on an
+// already-connected client is a no-op (returns nil, does not re-dial).
+func TestWSClient_Connect_Idempotent(t *testing.T) {
+	srv := newRawWSServer(t, func(conn *websocket.Conn) {
+		for {
+			var req requestFrame
+			if err := conn.ReadJSON(&req); err != nil {
+				return
+			}
+			conn.WriteJSON(responseFrame{Type: "res", ID: req.ID, OK: true})
+		}
+	})
+	defer srv.Close()
+
+	c := NewWSClient(srv.URL, "tok", "", "")
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("first Connect: %v", err)
+	}
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("second Connect should be a no-op, got error: %v", err)
+	}
+	c.Close()
+}
+
+// TestWSClient_Call_AfterServerClose_ClearsConn verifies the self-heal
+// path: when the server closes the WS, IsConnected() flips to false so the
+// next ensureWS reconnects. Without this, every subsequent Call would hit
+// the same dead conn until pod restart.
+func TestWSClient_Call_AfterServerClose_ClearsConn(t *testing.T) {
+	handshakeDone := make(chan struct{})
+	srv := newRawWSServer(t, func(conn *websocket.Conn) {
+		var req requestFrame
+		conn.ReadJSON(&req)
+		conn.WriteJSON(responseFrame{Type: "res", ID: req.ID, OK: true})
+		close(handshakeDone)
+		// Hang up immediately.
+	})
+	defer srv.Close()
+
+	c := NewWSClient(srv.URL, "tok", "", "")
+	if err := c.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	<-handshakeDone
+
+	// readLoop's deferred clearConnIfSame will fire after ReadMessage sees the
+	// close. Wait for done to close — that bounds the test without a flaky sleep.
+	select {
+	case <-c.done:
+	case <-makeTimeout(2 * time.Second):
+		t.Fatal("readLoop did not exit within 2s after server close")
+	}
+	if c.IsConnected() {
+		t.Error("expected IsConnected=false after server-side close")
+	}
+
+	// Now exercise the write-failure clearConnIfSame path explicitly: re-attach
+	// a stale conn and verify a failed Call() leaves IsConnected=false.
+	// (The readLoop path already flipped it false; this asserts the write-failure
+	// branch is also wired to clearConnIfSame.)
+	// Reconnect via a server that immediately drops on first request:
+	dropSrv := newRawWSServer(t, func(conn *websocket.Conn) {
+		var req requestFrame
+		conn.ReadJSON(&req)
+		conn.WriteJSON(responseFrame{Type: "res", ID: req.ID, OK: true})
+		conn.Close()
+	})
+	defer dropSrv.Close()
+	c2 := NewWSClient(dropSrv.URL, "tok", "", "")
+	if err := c2.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect c2: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_, _ = c2.Call(ctx, "ping", nil) // expected to error; we only assert IsConnected after
+	if c2.IsConnected() {
+		t.Error("expected IsConnected=false after Call against dropped conn")
+	}
+}
+
+func makeTimeout(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+// Ensure json import is exercised even if no test above uses it explicitly.
+var _ = json.RawMessage{}


### PR DESCRIPTION
## Why
Production gcplane pod stuck at 1/2 Ready (readyz=503) for 30+ min after a routine deploy. Diagnosis on the live pod (\`gcplane-57c64dcb58-554zv\`):

\`\`\`
06:10:33  WARN  observe failed  kind=AgentTeam name=media  error="ws write: broken pipe"
06:10:33  INFO  reconcile complete  updates=5 applied=5  failed=0    ← but plan.Errors non-empty
06:10:55  INFO  manifest unchanged, skipping  hash=24e7b7e94bc7      ← from here, every tick
... (40+ ticks, all skip; Synced=False latched; /readyz 503)
\`\`\`

Two interlocking bugs.

### Bug 1 — WSClient never recovers from a dropped connection
- \`Provider.wsReady\` was a write-once flag.
- \`WSClient.readLoop\` detected ReadMessage errors → cancelled pending waiters → returned. **Did not clear \`c.conn\`.**
- After a server-side close or broken pipe, \`ensureWS()\` still returned nil (\"already ready\"); every subsequent \`Call()\` wrote to a dead socket forever.
- Today's prod incident only escaped because all later reconciles short-circuited on the unchanged manifest — but the next real manifest change would have cascaded into mass WS failures.

### Bug 2 — \`Synced=False\` latches forever when manifest is stable
- An errored reconcile correctly set \`Synced=False\`.
- The next tick saw \`hash == lastHash\` → \`\"manifest unchanged, skipping\"\` → returned **before** touching the condition flags.
- \`/readyz\` stayed 503 indefinitely; even \`POST /api/v1/sync/<tenant>\` short-circuited on hash equality. **The pod had no recovery path short of restart.**

## What
- **WSClient**
  - \`readLoop\` defers \`clearConnIfSame(conn)\` → \`IsConnected()\` flips false on server-side close.
  - \`Call()\` calls \`clearConnIfSame\` on \`WriteJSON\` failure → broken pipe during a write self-clears.
  - New \`IsConnected()\` reads \`c.conn\` under lock.
  - \`Connect()\` is now idempotent (no-op when already connected).
- **Provider**
  - Drops the \`wsReady\` cache; \`ensureWS\` asks \`WSClient.IsConnected()\` for the real socket state and reconnects when false.
- **Controller**
  - Tracks \`lastHasErrors\`. The manifest-unchanged short-circuit is gated on \`!lastHasErrors\` — when prior errors exist we retry the full engine. Bounded to one extra reconcile per error; self-heals readyz within one cycle (~30s).

## Tests
- \`TestWSClient_IsConnected_FalseAfterServerClose\`
- \`TestWSClient_Connect_Idempotent\`
- \`TestWSClient_Call_AfterServerClose_ClearsConn\`
- \`TestReconcileOnce_HashSkip_RetriesAfterPriorError\`

All pre-existing tests pass.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — zero failures
- [x] New tests cover both fixes end-to-end (readLoop close path, write-failure path, controller retry path)
- [ ] Deploy: observe current degraded pod recovers within one reconcile cycle after image rollover; subsequent intentional manifest pushes trigger drift-detected → updating-resource without 503 lag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error recovery: the controller now retries reconciliation when previous attempts failed, even if the manifest hash remains unchanged, preventing the system from remaining stuck in a failed state.
  * Enhanced WebSocket resilience: connections now auto-recover after unexpected drops, ensuring more reliable communication with improved self-healing behavior.

* **Tests**
  * Added comprehensive test coverage for error recovery and connection lifecycle management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dataplanelabs/gcplane/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->