### PR TITLE
fix(skills): upload sourceDir updates

### DIFF
--- a/internal/provider/goclaw/skill_test.go
+++ b/internal/provider/goclaw/skill_test.go
@@ -237,6 +237,49 @@ func TestSkill_Create_UploadsZIP(t *testing.T) {
 	}
 }
 
+func TestSkill_Update_WithSourceDirUploadsZIP(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: Test Skill\nslug: test-skill\ndescription: hi\n---\nbody\n"), 0o644); err != nil {
+		t.Fatalf("write SKILL.md: %v", err)
+	}
+
+	gotUpload := false
+	p, cleanup := newTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/skills/upload":
+			gotUpload = true
+			if err := r.ParseMultipartForm(8 << 20); err != nil {
+				t.Errorf("parse multipart: %v", err)
+			}
+			if got := r.FormValue("source"); got != "gcplane" {
+				t.Errorf("expected source=gcplane form field, got %q", got)
+			}
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]any{"slug": "test-skill", "status": "unchanged"})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/skills":
+			json.NewEncoder(w).Encode(map[string]any{
+				"skills": []map[string]any{{"id": "skill-uuid", "slug": "test-skill"}},
+			})
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/skills/skill-uuid":
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/agents":
+			json.NewEncoder(w).Encode(map[string]any{"agents": []map[string]any{}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer cleanup()
+
+	if err := p.Update(context.Background(), manifest.KindSkill, "test-skill", map[string]any{
+		"sourceDir": dir,
+	}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !gotUpload {
+		t.Fatal("expected update with sourceDir to upload skill package")
+	}
+}
+
 // TestSkill_Update_ReconcilesGrants verifies update path: when spec declares
 // grants.agents=[van-anh], a currently-granted [old-bot] is revoked and
 // van-anh is granted.

--- a/internal/provider/goclaw/skills.go
+++ b/internal/provider/goclaw/skills.go
@@ -191,6 +191,9 @@ func (p *Provider) deleteSkill(ctx context.Context, key string) error {
 // updateSkill updates an existing skill in GoClaw.
 // Sends only writable fields, then reconciles per-agent grants.
 func (p *Provider) updateSkill(ctx context.Context, key string, spec map[string]any) error {
+	if sourceDir, _ := spec["sourceDir"].(string); sourceDir != "" {
+		return p.createSkill(ctx, key, spec)
+	}
 	if err := p.putSkillFields(ctx, key, spec); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Reconcile gcplane-managed skill packages through upload when sourceDir is present on update
- Preserve source=gcplane on idempotent uploads so GoClaw owns provenance correctly
- Add provider test coverage for the update upload path

## Verification
- go test ./internal/provider/goclaw -count=1
- go run . validate -f /Users/vanducng/git/personal/dataplanelabs/goclaw-config/annhien