### PR TITLE
ci(release): serialize tag publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ on:
   push:
     tags: ['v*']
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write


### PR DESCRIPTION
## Summary
- add release workflow concurrency by tag ref
- cancel duplicate in-progress release jobs for the same tag so GoReleaser cannot race while publishing the same GitHub release

## Verification
- inspected failed v1.7.5 duplicate release logs: one job published successfully, the duplicate failed with tag_name already_exists