### PR TITLE
fix(sync): reconcile unchanged manifests for drift

### DIFF
--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -37,7 +37,6 @@ type Controller struct {
 	triggerCh      chan struct{}
 	logger         *slog.Logger
 	lastHash       string
-	lastHasErrors  bool // true when the previous reconcile produced errors; gates the unchanged-manifest skip so transient failures self-heal
 	debounceWindow time.Duration
 	debounceTimer  *time.Timer
 	mu             sync.Mutex
@@ -172,24 +171,16 @@ func (c *Controller) reconcileOnce() {
 		return
 	}
 
-	// Skip if manifest unchanged AND prior reconcile succeeded. If the previous
-	// reconcile had errors (e.g. transient WS broken pipe, observe failure), a
-	// hash-equality skip would latch Synced=False forever — /readyz never
-	// recovers until a manifest change forces another full reconcile. Retrying
-	// the engine when prior errors exist self-heals within one cycle and is
-	// bounded (one extra reconcile per error).
-	if hash == c.lastHash && hash != "" && !c.lastHasErrors {
+	// A matching source hash only means the GitOps input has not changed; it
+	// does not prove the provider state still matches that input. Always run
+	// reconciliation so manual edits, failed side effects, and partially applied
+	// grants heal without requiring a no-op config commit.
+	if hash == c.lastHash && hash != "" {
 		display := hash
 		if len(display) > 12 {
 			display = display[:12]
 		}
-		c.logger.Info("manifest unchanged, skipping", "hash", display)
-		// Notify waiters with a no-op result so TriggerAndWait doesn't block forever.
-		c.notifyWaiters(&SyncResult{})
-		return
-	}
-	if hash == c.lastHash && hash != "" && c.lastHasErrors {
-		c.logger.Info("manifest unchanged but prior reconcile errored — retrying to self-heal")
+		c.logger.Info("manifest unchanged, checking provider drift", "hash", display)
 	}
 
 	engine := reconciler.NewEngine(c.provider, c.logger)
@@ -207,8 +198,6 @@ func (c *Controller) reconcileOnce() {
 
 	hasErrors := result.Failed > 0 || len(plan.Errors) > 0
 	hasDrift := plan.Creates > 0 || plan.Updates > 0
-	c.lastHasErrors = hasErrors
-
 	if hasErrors {
 		c.tracker.SetCondition(Condition{Type: ConditionSynced, Status: "False"})
 		c.tracker.SetCondition(Condition{Type: ConditionError, Status: "True", Message: "sync completed with errors"})

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -136,20 +136,19 @@ func TestReconcileOnce_SuccessfulReconcile_IncrementsSuccess(t *testing.T) {
 	}
 }
 
-func TestReconcileOnce_HashSkip_NoSecondReconcile(t *testing.T) {
+func TestReconcileOnce_HashUnchanged_StillChecksDrift(t *testing.T) {
 	src := &mockSource{manifest: minimalManifest(), hash: "aabbccddeeff0011"} // ≥12 chars for hash[:12] in controller
 	ctrl := newTestController(src, &mockProvider{})
 
 	ctrl.reconcileOnce() // sets lastHash
-	ctrl.reconcileOnce() // should skip because hash unchanged
+	ctrl.reconcileOnce() // should still reconcile because provider state can drift
 
 	if src.calls.Load() != 2 {
 		t.Errorf("expected Fetch called twice, got %d", src.calls.Load())
 	}
-	// Only first call does real work; metrics should show 1 success
 	snap := ctrl.metrics.Snapshot()
-	if snap.SyncSuccess != 1 {
-		t.Errorf("expected SyncSuccess=1 (second call skipped), got %d", snap.SyncSuccess)
+	if snap.SyncSuccess != 2 {
+		t.Errorf("expected SyncSuccess=2 (same hash still reconciles), got %d", snap.SyncSuccess)
 	}
 }
 
@@ -471,13 +470,10 @@ func TestMetrics_Snapshot_ThreadSafe(t *testing.T) {
 	close(done)
 }
 
-// TestReconcileOnce_HashSkip_RetriesAfterPriorError verifies the self-heal
-// behavior: when a reconcile completes with errors, the next "manifest
-// unchanged" tick must NOT short-circuit — otherwise Synced=False latches
-// forever (readyz returns 503 until manifest changes). Regression for the
-// production bug where a transient observe broken-pipe left the pod
-// permanently NotReady.
-func TestReconcileOnce_HashSkip_RetriesAfterPriorError(t *testing.T) {
+// TestReconcileOnce_HashUnchanged_RunsAfterPriorError verifies the self-heal
+// behavior: provider drift checks run even when the source hash is unchanged,
+// so transient observe failures recover without a no-op config commit.
+func TestReconcileOnce_HashUnchanged_RunsAfterPriorError(t *testing.T) {
 	src := &mockSource{
 		manifest: &manifest.Manifest{
 			APIVersion: "gcplane.io/v1",
@@ -495,12 +491,12 @@ func TestReconcileOnce_HashSkip_RetriesAfterPriorError(t *testing.T) {
 	ctrl := newTestController(src, prov)
 
 	ctrl.reconcileOnce()
-	if !ctrl.lastHasErrors {
-		t.Fatal("expected lastHasErrors=true after observe failure")
+	if ctrl.metrics.Snapshot().SyncErrors != 1 {
+		t.Fatal("expected SyncErrors=1 after observe failure")
 	}
 
-	// Second reconcile with same hash: would normally skip, but lastHasErrors
-	// must force a retry. Heal the underlying error so the retry succeeds.
+	// Second reconcile with same hash still runs. Heal the underlying error so
+	// the retry succeeds.
 	prov.observeErr = nil
 	prov.observeResult = nil // → ActionCreate path; createErr=nil → applied
 	beforeCalls := src.calls.Load()
@@ -508,15 +504,15 @@ func TestReconcileOnce_HashSkip_RetriesAfterPriorError(t *testing.T) {
 	if src.calls.Load() != beforeCalls+1 {
 		t.Errorf("expected Fetch called once more (retry), got delta %d", src.calls.Load()-beforeCalls)
 	}
-	if ctrl.lastHasErrors {
-		t.Error("expected lastHasErrors=false after successful retry")
+	if ctrl.metrics.Snapshot().SyncSuccess != 1 {
+		t.Errorf("expected SyncSuccess=1 after successful retry, got %d", ctrl.metrics.Snapshot().SyncSuccess)
 	}
 
-	// Third reconcile with same hash and no prior error: should now skip normally.
+	// Third reconcile with same hash still checks provider drift.
 	beforeSuccess := ctrl.metrics.Snapshot().SyncSuccess
 	ctrl.reconcileOnce()
-	if ctrl.metrics.Snapshot().SyncSuccess != beforeSuccess {
-		t.Errorf("expected third call to skip (no metrics delta), got SyncSuccess delta %d",
+	if ctrl.metrics.Snapshot().SyncSuccess != beforeSuccess+1 {
+		t.Errorf("expected third call to reconcile, got SyncSuccess delta %d",
 			ctrl.metrics.Snapshot().SyncSuccess-beforeSuccess)
 	}
 }

--- a/internal/provider/goclaw/team_test.go
+++ b/internal/provider/goclaw/team_test.go
@@ -65,7 +65,22 @@ func TestTeam_Update(t *testing.T) {
 				{"id": "t-uuid", "name": "alpha-team"},
 			},
 		}},
-		{method: "teams.update", ok: true, payload: map[string]any{"ok": true}},
+		{method: "teams.update", ok: true, payload: map[string]any{"ok": true}, assertParams: func(t *testing.T, params any) {
+			t.Helper()
+			got, ok := params.(map[string]any)
+			if !ok {
+				t.Fatalf("teams.update params = %T, want map[string]any", params)
+			}
+			if got["teamId"] != "t-uuid" {
+				t.Fatalf("teamId = %v, want t-uuid", got["teamId"])
+			}
+			if _, hasPatch := got["patch"]; hasPatch {
+				t.Fatalf("teams.update should send fields at top level, got nested patch: %#v", got)
+			}
+			if got["description"] != "Updated" {
+				t.Fatalf("description = %v, want Updated", got["description"])
+			}
+		}},
 	}, nil)
 	defer cleanup()
 

--- a/internal/provider/goclaw/teams.go
+++ b/internal/provider/goclaw/teams.go
@@ -68,10 +68,8 @@ func (p *Provider) updateTeam(ctx context.Context, key string, spec map[string]a
 		teamID = strVal(current, "name")
 	}
 
-	params := map[string]any{
-		"teamId": teamID,
-		"patch":  translateSpec(spec),
-	}
+	params := translateSpec(spec)
+	params["teamId"] = teamID
 
 	_, err = p.ws.Call(ctx, "teams.update", params)
 	if err != nil {

--- a/internal/provider/goclaw/ws_test_helpers_test.go
+++ b/internal/provider/goclaw/ws_test_helpers_test.go
@@ -11,9 +11,10 @@ import (
 
 // wsResponse describes one canned RPC response for the mock WS server.
 type wsResponse struct {
-	method  string
-	payload any
-	ok      bool
+	method       string
+	payload      any
+	ok           bool
+	assertParams func(*testing.T, any)
 }
 
 // newWSTestServer creates an httptest server with both HTTP routes and a WebSocket
@@ -67,6 +68,10 @@ func newWSTestServer(t *testing.T, responses []wsResponse, httpRoutes http.Handl
 					Error: &rpcError{Message: "method not found: " + req.Method},
 				})
 				continue
+			}
+
+			if rr.assertParams != nil {
+				rr.assertParams(t, req.Params)
 			}
 
 			payload, _ := json.Marshal(rr.payload)
@@ -149,4 +154,3 @@ func newWSTestServerSmart(t *testing.T, agents []map[string]any, linksByAgentID 
 	p := New(srv.URL, "test-token")
 	return p, srv.Close
 }
-

--- a/internal/reconciler/compare.go
+++ b/internal/reconciler/compare.go
@@ -125,6 +125,12 @@ func toSlice(v any) ([]any, bool) {
 	switch s := v.(type) {
 	case []any:
 		return s, true
+	case []string:
+		out := make([]any, len(s))
+		for i, v := range s {
+			out[i] = v
+		}
+		return out, true
 	default:
 		return nil, false
 	}

--- a/internal/reconciler/compare_test.go
+++ b/internal/reconciler/compare_test.go
@@ -103,3 +103,19 @@ func TestCompareSpec_NumericTypeEquality(t *testing.T) {
 		t.Errorf("expected numeric types to match, got diffs: %v", diffs)
 	}
 }
+
+func TestCompareSpec_StringSliceTypeEquality(t *testing.T) {
+	// YAML/frontmatter overlays commonly become []any while provider-observed
+	// grant lists are native []string. They are semantically identical.
+	desired := map[string]any{
+		"grants": map[string]any{"agents": []any{"agent-a", "agent-b"}},
+	}
+	actual := map[string]any{
+		"grants": map[string]any{"agents": []string{"agent-a", "agent-b"}},
+	}
+
+	diffs := CompareSpec(desired, actual)
+	if len(diffs) != 0 {
+		t.Errorf("expected string slices with different concrete types to match, got diffs: %v", diffs)
+	}
+}


### PR DESCRIPTION
## Summary
- keep gcplane serve reconciling provider state even when the git source hash is unchanged
- fix teams.update payload shape so team settings actually apply
- normalize []any and []string slices to avoid noisy grant drift

## Tests
- go test ./...
- git diff --check