### PR TITLE
fix(reconcile): avoid stable-state drift loops

### DIFF
--- a/internal/manifest/field_config.go
+++ b/internal/manifest/field_config.go
@@ -4,8 +4,8 @@ package manifest
 // by the GoClaw API (secrets, UUIDs, grants managed separately).
 // These fields are excluded from comparison during reconciliation.
 var writeOnlyFields = map[ResourceKind][]string{
-	KindTenant:            {},
-	KindProvider:          {"apiKey"},
+	KindTenant:   {},
+	KindProvider: {"apiKey"},
 	KindAgent: {
 		"contextFiles", "systemPrompt",
 		// Complex JSONB configs — sent on create/update but not compared
@@ -16,10 +16,10 @@ var writeOnlyFields = map[ResourceKind][]string{
 		"reasoningConfig", "workspaceSharing", "chatgptOauthRouting",
 		"shellDenyGroups", "kgDedupConfig",
 	},
-	KindChannel:           {"agentKey", "credentials", "config"},
-	KindMCPServer:         {"grants"},
-	KindCronJob:           {"agentKey", "message"},
-	KindAgentTeam:         {"lead", "members", "displayName"},
+	KindChannel:   {"agentKey", "credentials", "config"},
+	KindMCPServer: {"grants", "headers"},
+	KindCronJob:   {"agentKey", "message"},
+	KindAgentTeam: {"lead", "members", "displayName"},
 	KindSkill: {
 		// sourceDir is the local filesystem path used by gcplane to build the
 		// upload ZIP; goclaw never returns it.
@@ -31,8 +31,8 @@ var writeOnlyFields = map[ResourceKind][]string{
 	KindBuiltinToolConfig: {}, // settings are observable via tenant_settings in list response
 	KindSkillConfig:       {},
 	KindSystemConfig:      {},
-	KindMCPCredentials:    {"credentials"},      // credentials are write-only (encrypted)
-	KindSecureCLI:         {"env"},              // encrypted env vars are write-only
+	KindMCPCredentials:    {"credentials"},            // credentials are write-only (encrypted)
+	KindSecureCLI:         {"env"},                    // encrypted env vars are write-only
 	KindSecureCLIGrant:    {"agentKey", "binaryName"}, // manifest references, not in API response
 	KindAgentLink: {
 		"sourceAgent", "targetAgent", // manifest references resolved to UUIDs at create time

--- a/internal/reconciler/compare.go
+++ b/internal/reconciler/compare.go
@@ -55,6 +55,13 @@ func compareRecursiveExcluding(prefix string, desired, actual map[string]any, di
 			continue
 		}
 
+		if unorderedStringSetPath(path) {
+			if !stringSetEqual(dVal, aVal) {
+				diffs[path] = FieldDiff{Old: aVal, New: dVal}
+			}
+			continue
+		}
+
 		// Compare values
 		if !valuesEqual(dVal, aVal) {
 			diffs[path] = FieldDiff{Old: aVal, New: dVal}
@@ -134,6 +141,45 @@ func toSlice(v any) ([]any, bool) {
 	default:
 		return nil, false
 	}
+}
+
+func unorderedStringSetPath(path string) bool {
+	switch path {
+	case "grants.agents", "grants.users":
+		return true
+	default:
+		return false
+	}
+}
+
+func stringSetEqual(a, b any) bool {
+	aStrings, aOK := toStringSet(a)
+	bStrings, bOK := toStringSet(b)
+	if !aOK || !bOK || len(aStrings) != len(bStrings) {
+		return false
+	}
+	for s := range aStrings {
+		if !bStrings[s] {
+			return false
+		}
+	}
+	return true
+}
+
+func toStringSet(v any) (map[string]bool, bool) {
+	slice, ok := toSlice(v)
+	if !ok {
+		return nil, false
+	}
+	out := make(map[string]bool, len(slice))
+	for _, item := range slice {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		out[s] = true
+	}
+	return out, true
 }
 
 func toFloat64(v any) (float64, bool) {

--- a/internal/reconciler/compare_test.go
+++ b/internal/reconciler/compare_test.go
@@ -119,3 +119,34 @@ func TestCompareSpec_StringSliceTypeEquality(t *testing.T) {
 		t.Errorf("expected string slices with different concrete types to match, got diffs: %v", diffs)
 	}
 }
+
+func TestCompareSpec_GrantAgentOrderIgnored(t *testing.T) {
+	desired := map[string]any{
+		"grants": map[string]any{"agents": []any{"agent-a", "agent-b", "agent-c"}},
+	}
+	actual := map[string]any{
+		"grants": map[string]any{"agents": []string{"agent-c", "agent-a", "agent-b"}},
+	}
+
+	diffs := CompareSpec(desired, actual)
+	if len(diffs) != 0 {
+		t.Errorf("expected grant agent order to be ignored, got diffs: %v", diffs)
+	}
+}
+
+func TestCompareSpec_GrantAgentSetDriftDetected(t *testing.T) {
+	desired := map[string]any{
+		"grants": map[string]any{"agents": []any{"agent-a", "agent-b"}},
+	}
+	actual := map[string]any{
+		"grants": map[string]any{"agents": []string{"agent-a", "agent-c"}},
+	}
+
+	diffs := CompareSpec(desired, actual)
+	if len(diffs) != 1 {
+		t.Fatalf("expected one grant set diff, got %d: %v", len(diffs), diffs)
+	}
+	if _, ok := diffs["grants.agents"]; !ok {
+		t.Errorf("expected grants.agents diff, got %v", diffs)
+	}
+}

--- a/internal/reconciler/engine_test.go
+++ b/internal/reconciler/engine_test.go
@@ -324,7 +324,7 @@ func TestReconcile_WriteOnlyHashMatchesNoop(t *testing.T) {
 
 	provider := newMockProvider()
 	provider.observed["Agent/bot"] = map[string]any{
-		"model":        "gpt-4",
+		"model":         "gpt-4",
 		"writeOnlyHash": expectedHash,
 	}
 
@@ -573,7 +573,7 @@ func TestWarnBlindNoop_NoWarnOnCreate(t *testing.T) {
 				Kind: manifest.KindBuiltinToolConfig,
 				Name: "create-image",
 				Spec: map[string]any{
-					"enabled": true,
+					"enabled":  true,
 					"settings": map[string]any{"providers": []any{"dashscope"}},
 				},
 			},
@@ -627,6 +627,40 @@ func TestWarnBlindNoop_GenericAcrossKinds(t *testing.T) {
 	}
 	if !strings.Contains(out, "grants") {
 		t.Errorf("expected 'grants' in warning log, got:\n%s", out)
+	}
+}
+
+func TestReconcile_MCPServerHeadersAreBlindNoop(t *testing.T) {
+	provider := newMockProvider()
+	provider.observed["MCPServer/search"] = map[string]any{
+		"transport": "http",
+		"url":       "http://search-mcp.local",
+	}
+
+	var buf bytes.Buffer
+	engine := NewEngine(provider, newTestLogger(&buf))
+	m := &manifest.Manifest{
+		Resources: []manifest.Resource{
+			{
+				Kind: manifest.KindMCPServer,
+				Name: "search",
+				Spec: map[string]any{
+					"transport": "http",
+					"url":       "http://search-mcp.local",
+					"headers":   map[string]any{"Authorization": "Bearer token"},
+				},
+			},
+		},
+	}
+
+	plan, _ := engine.Reconcile(context.Background(), m, ReconcileOpts{DryRun: true})
+	if plan.Noops != 1 || plan.Updates != 0 {
+		t.Fatalf("expected blind noop for unobservable headers, got noops=%d updates=%d", plan.Noops, plan.Updates)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "no-op may hide drift") || !strings.Contains(out, "headers") {
+		t.Errorf("expected blind-noop warning for MCPServer headers, got:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- compare grant agent/user lists as unordered sets
- treat MCP server headers as write-only so unobservable headers do not trigger every sync cycle
- keep blind-noop warnings for unobservable MCP fields

## Verification
- go test ./...
- patched gcplane diff reports no drift for master, shtp, and annhien against live GoClaw