### PR TITLE
fix(cron): observe disabled crons (includeDisabled) to stop spurious CREATE churn

### DIFF
--- a/internal/provider/goclaw/cron_job_test.go
+++ b/internal/provider/goclaw/cron_job_test.go
@@ -9,6 +9,42 @@ import (
 	"github.com/dataplanelabs/gcplane/internal/manifest"
 )
 
+// Regression: a disabled cron must still be observed. cron.list omits disabled
+// jobs unless includeDisabled=true; without it the reconciler never sees an
+// enabled=false manifest cron and re-issues CREATE every cycle (duplicate key).
+func TestCronJob_Observe_DisabledIncluded(t *testing.T) {
+	p, cleanup := newWSTestServer(t, []wsResponse{
+		{method: "cron.list", ok: true,
+			assertParams: func(t *testing.T, params any) {
+				t.Helper()
+				got, ok := params.(map[string]any)
+				if !ok {
+					t.Fatalf("cron.list params = %T, want map[string]any (includeDisabled must be sent)", params)
+				}
+				if got["includeDisabled"] != true {
+					t.Fatalf("cron.list includeDisabled = %v, want true", got["includeDisabled"])
+				}
+			},
+			payload: map[string]any{
+				"jobs": []map[string]any{
+					{"id": "j9", "name": "kpi-weekly-report", "enabled": false, "schedule": "0 8 * * 1"},
+				},
+			}},
+	}, nil)
+	defer cleanup()
+
+	result, err := p.Observe(context.Background(), manifest.KindCronJob, "kpi-weekly-report")
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected disabled cron to be observed, got nil (would trigger spurious CREATE)")
+	}
+	if result["name"] != "kpi-weekly-report" {
+		t.Errorf("name = %v, want kpi-weekly-report", result["name"])
+	}
+}
+
 func TestCronJob_Observe_Found(t *testing.T) {
 	p, cleanup := newWSTestServer(t, []wsResponse{
 		{method: "cron.list", ok: true, payload: map[string]any{

--- a/internal/provider/goclaw/cron_jobs.go
+++ b/internal/provider/goclaw/cron_jobs.go
@@ -21,7 +21,10 @@ func (p *Provider) observeCronJob(ctx context.Context, key string) (map[string]a
 		return nil, fmt.Errorf("ws connect for cron: %w", err)
 	}
 
-	payload, err := p.ws.Call(ctx, "cron.list", nil)
+	// includeDisabled: cron.list omits disabled jobs by default. Without this,
+	// a manifest cron with enabled=false is never observed, so the reconciler
+	// re-issues CREATE every cycle and hits the (agent,tenant,name) unique key.
+	payload, err := p.ws.Call(ctx, "cron.list", map[string]any{"includeDisabled": true})
 	if err != nil {
 		return nil, fmt.Errorf("cron.list: %w", err)
 	}

--- a/internal/provider/goclaw/list_all.go
+++ b/internal/provider/goclaw/list_all.go
@@ -144,7 +144,8 @@ func (p *Provider) listAllCronJobs(ctx context.Context) ([]reconciler.ResourceIn
 	if err := p.ensureWS(ctx); err != nil {
 		return nil, fmt.Errorf("ws connect for cron: %w", err)
 	}
-	payload, err := p.ws.Call(ctx, "cron.list", nil)
+	// includeDisabled so prune/diff sees disabled crons too (matches observeCronJob).
+	payload, err := p.ws.Call(ctx, "cron.list", map[string]any{"includeDisabled": true})
 	if err != nil {
 		return nil, fmt.Errorf("cron.list: %w", err)
 	}


### PR DESCRIPTION
## Problem

`cron.list` omits disabled jobs by default. `observeCronJob` calls it with `nil` params, so a manifest cron declared `enabled: false` is **never observed**. The reconciler then decides `action=create` every cycle and hits `uq_cron_jobs_agent_tenant_name` (duplicate key, SQLSTATE 23505), wedging the tenant at `Synced=False`.

Because `/readyz` (`Server.isReady()`) requires **all** tenants Synced=True, one tenant's permanent `failed>0` keeps the whole gcplane pod `0/1` ready indefinitely.

### Observed on everest (prod)
- annhien tenant: `kpi-weekly-report` + `kpi-reminder-saturday` (both `enabled: false`, rows already exist disabled in DB) → `create failed ... duplicate key` every ~30s, `failed=2` each reconcile.
- gcplane pod stuck `1/2` / deploy `0/1` for 13 days (readiness probe failing, 0 restarts).

## Fix
Pass `includeDisabled: true` to `cron.list` in:
- `observeCronJob` (cron_jobs.go) — so disabled crons are observed → diffed to **Noop** instead of Create.
- `listAllCronJobs` (list_all.go) — so prune/diff also sees disabled crons.

GoClaw's `cron.list` handler already decodes `includeDisabled bool` and filters `enabled=true` only when false, so this is the intended knob.

Adds a regression test asserting the param is sent **and** a disabled cron is observed (non-nil).

## Interim mitigation already shipped
goclaw-config annotated the two annhien crons with `gcplane.io/sync-policy: Ignore` to stop the churn immediately — readiness recovered to `1/1`. That annotation can be removed once this lands.

## Test
`go build ./...`, `go vet`, `go test ./internal/provider/goclaw/ ./internal/reconciler/` all green.