### PR TITLE
chore(ci): bump go 1.25.10 -> 1.25.11 (fix stdlib vulns)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dataplanelabs/gcplane
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/gdamore/tcell/v2 v2.8.1


### PR DESCRIPTION
Bumps the Go toolchain to **1.25.11** to clear the two stdlib vulnerabilities govulncheck flags on 1.25.10:

- `GO-2026-5039` — arbitrary inputs unescaped in `net/textproto` errors (reached via `websocket.Dialer.DialContext`).
- `GO-2026-5037` — inefficient candidate hostname parsing in `crypto/x509`.

Both are **Fixed in go1.25.11**. All CI jobs use `go-version-file: go.mod`, so the single `go.mod` bump applies the toolchain to build/test/lint/**vuln**/e2e/release. The Dockerfile's `golang:1.25-alpine` already tracks the latest 1.25.x.

Verified `go build ./...` clean on go1.25.11 locally. Expect the `vuln` check to go green here.